### PR TITLE
Fix compatibility with synfony console 4-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.2.1 (2024-07-20)
 
+## What's Changed
+* Fixed asset file extension detection by @roxblnfk
+* Updated min version of `yiisoft/injector` by @roxblnfk
+
 **Full Changelog**: https://github.com/php-internal/dload/compare/0.2.0...0.2.1
 
 ## 0.2.0 (2024-07-19)

--- a/bin/dload
+++ b/bin/dload
@@ -51,5 +51,6 @@ if ('cli' !== PHP_SAPI) {
     );
     $application->setDefaultCommand(Command\Get::getDefaultName(), false);
     $application->setVersion(Info::version());
+    $application->setName(Info::NAME);
     $application->run();
 })();

--- a/src/Command/Get.php
+++ b/src/Command/Get.php
@@ -12,7 +12,6 @@ use Internal\DLoad\Module\Common\OperatingSystem;
 use Internal\DLoad\Module\Common\Stability;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,7 +24,7 @@ use Symfony\Component\Console\Output\OutputInterface;
     name: 'get',
     description: 'Download a binary',
 )]
-final class Get extends Base implements SignalableCommandInterface
+final class Get extends Base
 {
     private const ARG_SOFTWARE = 'software';
 
@@ -37,30 +36,6 @@ final class Get extends Base implements SignalableCommandInterface
         $this->addOption('arch', null, InputOption::VALUE_OPTIONAL, 'Architecture, e.g. "amd64", "arm64" etc.');
         $this->addOption('os', null, InputOption::VALUE_OPTIONAL, 'Operating system, e.g. "linux", "darwin" etc.');
         $this->addOption('stability', null, InputOption::VALUE_OPTIONAL, 'Stability, e.g. "stable", "beta" etc.');
-    }
-
-    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
-    {
-        if (\defined('SIGINT') && $signal === \SIGINT) {
-            $this->cancelling = true;
-        }
-
-        if (\defined('SIGTERM') && $signal === \SIGTERM) {
-            return $signal;
-        }
-
-        return false;
-    }
-
-    public function getSubscribedSignals(): array
-    {
-        $result = [];
-        /** @psalm-suppress MixedAssignment */
-        \defined('SIGINT') and $result[] = \SIGINT;
-        /** @psalm-suppress MixedAssignment */
-        \defined('SIGTERM') and $result[] = \SIGTERM;
-
-        return $result;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int


### PR DESCRIPTION

## What was changed

remove `SignalableCommandInterface` from the `get` command to be compatible with SF Console 4.x, 5.x; fix changelog and program version

## Why?

The program fails on lowest dependencies

## Checklist

- Closes #<!-- add issue number here -->
- Tested
  - [x] Tested manually
  - [ ] Unit tests added
