### PR TITLE
Add more stability markers

### DIFF
--- a/src/DLoad.php
+++ b/src/DLoad.php
@@ -204,16 +204,17 @@ final class DLoad
                     continue;
                 }
 
+                $isOverwriting = $to->isFile();
                 $extractor->send($to);
 
                 // Success
                 $path = $to->getRealPath() ?: $to->getPathname();
                 $this->output->writeln(
                     \sprintf(
-                        '%s (<comment>%s</comment>) has been installed%s into <info>%s</info>',
+                        '%s (<comment>%s</comment>) has been %sinstalled into <info>%s</info>',
                         $to->getFilename(),
                         $downloadResult->version,
-                        $to->isFile() ? ' (overwriting)' : '',
+                        $isOverwriting ? 're' : '',
                         $path,
                     ),
                 );

--- a/src/Module/Common/FileSystem/Path.php
+++ b/src/Module/Common/FileSystem/Path.php
@@ -90,6 +90,35 @@ final class Path implements \Stringable
     }
 
     /**
+     * Return the parent directory path
+     */
+    public function parent(): self
+    {
+        $parts = \explode(self::DS, $this->path);
+
+        if (\count($parts) === 1) {
+            return match ($this->path) {
+                '.' => self::create('..'),
+                '..' => self::create('../..'),
+                default => self::create('.'),
+            };
+        }
+
+        if ($this->isAbsolute && \count($parts) === 2) {
+            // If the path is absolute and has only two parts, return the root
+            return self::create($parts[0] . self::DS);
+        }
+
+        if (!$this->isAbsolute && $parts[\array_key_last($parts)] === '..') {
+            return $this->join('..');
+        }
+
+        // Remove the last part of the path
+        \array_pop($parts);
+        return self::create(\implode(self::DS, $parts));
+    }
+
+    /**
      * Return whether this path is absolute
      */
     public function isAbsolute(): bool

--- a/src/Module/Common/Stability.php
+++ b/src/Module/Common/Stability.php
@@ -61,7 +61,7 @@ enum Stability: string implements Factoriable
      */
     public static function parse(string $version): self
     {
-        $version = (string) \preg_replace('{#.+$}', '', $version);
+        $version = (string) \preg_replace('{#.+$}', '', \ltrim($version, 'v'));
 
         if (\preg_match('{^dev[-_.]}', $version) || \preg_match('{[-_.]dev$}', $version)) {
             return self::Dev;
@@ -69,7 +69,7 @@ enum Stability: string implements Factoriable
 
 
         $mods = \implode('|', \array_column(self::cases(), 'value')) . '|b|a|[a-z]';
-        $reg = "[._-]?(?:($mods)((?:[.-]?\d+)*+)?)?([.-]?dev)?";
+        $reg = "[._-]?(?:($mods)((?:[.-]?\d+)*+)?)?";
 
         \preg_match('{' . $reg . '(?:\+.*)?$}i', \strtolower($version), $match);
 
@@ -89,7 +89,7 @@ enum Stability: string implements Factoriable
         return match ($suffix) {
             'a' => self::Alpha,
             'b' => self::Beta,
-            default => self::Stable,
+            default => self::Dev,
         };
     }
 

--- a/src/Module/Common/Stability.php
+++ b/src/Module/Common/Stability.php
@@ -25,30 +25,54 @@ use Internal\DLoad\Service\Factoriable;
  */
 enum Stability: string implements Factoriable
 {
-    case Stable = 'stable';
-    case RC = 'RC';
-    case Beta = 'beta';
-    case Alpha = 'alpha';
-    case Dev = 'dev';
+    case Stable = 'stable';       // Released version considered stable for production
+    case RC = 'RC';               // Almost ready for stable release
+    case Priority = 'priority';   // High priority pre-release
+    case Pre = 'pre';             // Close to final
+    case Beta = 'beta';           // Feature complete but may have bugs
+    case Preview = 'preview';     // Demonstrates functionality but incomplete
+    case Alpha = 'alpha';         // Early testing, incomplete features
+    case Unstable = 'unstable';   // May crash or have major issues
+    case Dev = 'dev';             // Active development
+    case Snapshot = 'snapshot';   // Point-in-time version of current development
+    case Nightly = 'nightly';     // Automatically generated daily build
 
+    /**
+     * Factory method to create a Stability instance from a Build configuration
+     */
     public static function create(Build $config): static
     {
         return self::tryFrom((string) $config->stability) ?? self::fromGlobals();
     }
 
+    /**
+     * Provides a default Stability value if none is specified
+     */
     public static function fromGlobals(): self
     {
         return self::Stable;
     }
 
+    /**
+     * Get the numerical weight of this stability level
+     * Higher numbers indicate more stable versions
+     *
+     * @return int<0, 10> The weight/priority of this stability level (0-9)
+     */
     public function getWeight(): int
     {
         return match ($this) {
-            self::Stable => 4,
-            self::RC => 3,
-            self::Beta => 2,
-            self::Alpha => 1,
-            self::Dev => 0,
+            self::Stable => 10,
+            self::RC => 9,
+            self::Priority => 8,
+            self::Pre => 7,
+            self::Beta => 6,
+            self::Preview => 5,
+            self::Alpha => 4,
+            self::Unstable => 3,
+            self::Dev => 2,
+            self::Snapshot => 1,
+            self::Nightly => 0,
         };
     }
 }

--- a/src/Module/Repository/Internal/Release.php
+++ b/src/Module/Repository/Internal/Release.php
@@ -78,7 +78,7 @@ abstract class Release implements ReleaseInterface
      */
     private function parseStability(string $version): Stability
     {
-        return Stability::tryFrom(VersionParser::parseStability($version));
+        return Stability::parse($version);
     }
 
     /**

--- a/tests/Unit/Module/Common/FileSystem/PathTest.php
+++ b/tests/Unit/Module/Common/FileSystem/PathTest.php
@@ -25,6 +25,18 @@ final class PathTest extends TestCase
         yield 'double dot path' => ['..', false];
     }
 
+    public static function providePathsForParent(): \Generator
+    {
+        yield ['.', '..'];
+        yield ['..', '../..'];
+        yield ['path/to/..', '.'];
+        yield ['/home', '/.'];
+        yield ['C:/Users', 'C:/.'];
+        yield ['C:/.', 'C:/.'];
+        yield ['filename.txt', '.'];
+        yield ['some/path/file.txt', 'some/path'];
+    }
+
     public function testCreateReturnsPathInstance(): void
     {
         // Arrange & Act
@@ -272,18 +284,6 @@ final class PathTest extends TestCase
 
         // Assert
         self::assertSame('hidden', $extension);
-    }
-
-    public static function providePathsForParent(): \Generator
-    {
-        yield ['.', '..'];
-        yield ['..', '../..'];
-        yield ['path/to/..', '.'];
-        yield ['/home', '/.'];
-        yield ['C:/Users', 'C:/.'];
-        yield ['C:/.', 'C:/.'];
-        yield ['filename.txt', '.'];
-        yield ['some/path/file.txt', 'some/path'];
     }
 
     #[DataProvider('providePathsForParent')]

--- a/tests/Unit/Module/Common/FileSystem/PathTest.php
+++ b/tests/Unit/Module/Common/FileSystem/PathTest.php
@@ -274,6 +274,31 @@ final class PathTest extends TestCase
         self::assertSame('hidden', $extension);
     }
 
+    public static function providePathsForParent(): \Generator
+    {
+        yield ['.', '..'];
+        yield ['..', '../..'];
+        yield ['path/to/..', '.'];
+        yield ['/home', '/.'];
+        yield ['C:/Users', 'C:/.'];
+        yield ['C:/.', 'C:/.'];
+        yield ['filename.txt', '.'];
+        yield ['some/path/file.txt', 'some/path'];
+    }
+
+    #[DataProvider('providePathsForParent')]
+    public function testParent(string $inputPath, string $expectedParent): void
+    {
+        // Arrange
+        $path = Path::create($inputPath);
+
+        // Act
+        $parent = $path->parent();
+
+        // Assert
+        self::assertSame($expectedParent, (string) $parent);
+    }
+
     #[DataProvider('providePathsForAbsoluteDetection')]
     public function testIsAbsolute(string $pathString, bool $expected): void
     {

--- a/tests/Unit/Module/Common/StabilityTest.php
+++ b/tests/Unit/Module/Common/StabilityTest.php
@@ -17,6 +17,30 @@ final class StabilityTest extends TestCase
      */
     public static function provideVersionsAndExpectedStability(): \Generator
     {
+        // Composer cases
+        yield ['1', Stability::Stable, ''];
+        yield ['1.0', Stability::Stable, ''];
+        yield ['3.2.1', Stability::Stable, ''];
+        yield ['v3.2.1', Stability::Stable, ''];
+        yield ['v2.0.x-dev', Stability::Dev, ''];
+        yield ['v2.0.x-dev#abc123', Stability::Dev, ''];
+        yield ['v2.0.x-dev#trunk/@123', Stability::Dev, ''];
+        yield ['3.0-RC2', Stability::RC, ''];
+        yield ['dev-master', Stability::Dev, ''];
+        yield ['3.1.2-dev', Stability::Dev, ''];
+        yield ['dev-feature+issue-1', Stability::Dev, ''];
+        yield ['3.1.2-p1', Stability::Dev, 'Composer expects Stable here'];
+        yield ['3.1.2-pl2', Stability::Dev, 'Composer expects Stable here'];
+        yield ['3.1.2-patch', Stability::Dev, 'Composer expects Stable here'];
+        yield ['3.1.2-alpha5', Stability::Alpha, ''];
+        yield ['3.1.2-beta', Stability::Beta, ''];
+        yield ['2.0B1', Stability::Beta, ''];
+        yield ['1.2.0a1', Stability::Alpha, ''];
+        yield ['1.2_a1', Stability::Alpha, ''];
+        yield ['2.0.0rc1', Stability::RC, ''];
+        yield ['1.0.0-alpha11+cs-1.1.0', Stability::Alpha, ''];
+        yield ['1-2_dev', Stability::Dev, ''];
+
         // Dev versions with prefix
         yield 'dev prefix - main' => ['dev-main', Stability::Dev, 'Dev-prefixed version'];
         yield 'dev prefix - master' => ['dev-master', Stability::Dev, 'Dev-prefixed version'];
@@ -51,7 +75,7 @@ final class StabilityTest extends TestCase
         // Abbreviated stability indicators
         yield 'alpha abbreviated' => ['1.0.0a1', Stability::Alpha, 'Alpha abbreviated'];
         yield 'beta abbreviated' => ['1.0.0b2', Stability::Beta, 'Beta abbreviated'];
-        yield 'unknown abbreviated' => ['1.0.0x3', Stability::Stable, 'Unknown abbreviated (defaults to Stable)'];
+        yield 'unknown abbreviated' => ['1.0.0x3', Stability::Dev, 'Unknown abbreviated (defaults to Stable)'];
 
         // Different separators
         yield 'dash separator' => ['1.0.0-beta1', Stability::Beta, 'Version with dash separator'];
@@ -60,6 +84,8 @@ final class StabilityTest extends TestCase
 
         // Real cases
         yield 'real case 1' => ['v1.0.0-priority.0', Stability::Priority, 'Temporal priority version'];
+        yield 'real case 2' => ['v1.3.1-nexus-cancellation.0', Stability::Dev, 'Temporal priority version'];
+        yield 'real case 3' => ['v1.3.0', Stability::Stable, 'Stable version'];
     }
 
     /**

--- a/tests/Unit/Module/Common/StabilityTest.php
+++ b/tests/Unit/Module/Common/StabilityTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\DLoad\Tests\Unit\Module\Common;
+
+use Internal\DLoad\Module\Common\Stability;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Stability::class)]
+final class StabilityTest extends TestCase
+{
+    /**
+     * Data provider for versions and their expected stability levels
+     */
+    public static function provideVersionsAndExpectedStability(): \Generator
+    {
+        // Dev versions with prefix
+        yield 'dev prefix - main' => ['dev-main', Stability::Dev, 'Dev-prefixed version'];
+        yield 'dev prefix - master' => ['dev-master', Stability::Dev, 'Dev-prefixed version'];
+        yield 'dev prefix - feature' => ['dev-feature-branch', Stability::Dev, 'Dev-prefixed version'];
+
+        // Dev versions with suffix
+        yield 'dev suffix - direct' => ['1.0.0-dev', Stability::Dev, 'Version with dev suffix'];
+        yield 'dev suffix - with number' => ['2.3.4-dev', Stability::Dev, 'Version with dev suffix'];
+
+        // Version with comment
+        yield 'version with comment' => ['1.0.0-beta#comment-part', Stability::Beta, 'Version with comment'];
+
+        // Dev versions with stability and dev suffix
+        yield 'beta with dev suffix 1' => ['1.0.0-beta.dev', Stability::Dev, 'Version with stability and dev suffix'];
+        yield 'beta with dev suffix 2' => ['1.0.0-beta-dev', Stability::Dev, 'Version with stability and dev suffix'];
+        yield 'alpha with dev suffix 1' => ['2.0.0-alpha.1.dev', Stability::Dev, 'Version with stability and dev suffix'];
+        yield 'alpha with dev suffix 2' => ['2.0.0-alpha.1-dev', Stability::Dev, 'Version with stability and dev suffix'];
+        yield 'rc with dev suffix 1' => ['3.0.0-rc.2-dev', Stability::Dev, 'Version with stability and dev suffix'];
+
+        // Named stability levels
+        yield 'stable version' => ['1.0.0', Stability::Stable, 'Stable version'];
+        yield 'RC version' => ['1.0.0-RC1', Stability::RC, 'RC version'];
+        yield 'priority version' => ['1.0.0-priority2', Stability::Priority, 'Priority version'];
+        yield 'pre version' => ['1.0.0-pre.3', Stability::Pre, 'Pre version'];
+        yield 'beta version' => ['1.0.0-beta4', Stability::Beta, 'Beta version'];
+        yield 'preview version' => ['1.0.0-preview5', Stability::Preview, 'Preview version'];
+        yield 'alpha version' => ['1.0.0-alpha6', Stability::Alpha, 'Alpha version'];
+        yield 'unstable version' => ['1.0.0-unstable7', Stability::Unstable, 'Unstable version'];
+        yield 'snapshot version' => ['1.0.0-snapshot', Stability::Snapshot, 'Snapshot version'];
+        yield 'nightly version' => ['1.0.0-nightly20250503', Stability::Nightly, 'Nightly version'];
+
+        // Abbreviated stability indicators
+        yield 'alpha abbreviated' => ['1.0.0a1', Stability::Alpha, 'Alpha abbreviated'];
+        yield 'beta abbreviated' => ['1.0.0b2', Stability::Beta, 'Beta abbreviated'];
+        yield 'unknown abbreviated' => ['1.0.0x3', Stability::Stable, 'Unknown abbreviated (defaults to Stable)'];
+
+        // Different separators
+        yield 'dash separator' => ['1.0.0-beta1', Stability::Beta, 'Version with dash separator'];
+        yield 'dot separator' => ['1.0.0.beta2', Stability::Beta, 'Version with dot separator'];
+        yield 'underscore separator' => ['1.0.0_beta3', Stability::Beta, 'Version with underscore separator'];
+
+        // Real cases
+        yield 'real case 1' => ['v1.0.0-priority.0', Stability::Priority, 'Temporal priority version'];
+    }
+
+    /**
+     * Tests that parseStability correctly identifies stability from version strings
+     */
+    #[DataProvider('provideVersionsAndExpectedStability')]
+    public function testParseStability(string $version, Stability $expected, string $description): void
+    {
+        // Act
+        $stability = Stability::parse($version);
+
+        // Assert
+        self::assertSame(
+            $expected,
+            $stability,
+            \sprintf('%s: Version "%s" should be recognized as %s stability', $description, $version, $expected->value),
+        );
+    }
+}


### PR DESCRIPTION
## What was changed

Added more unstable release prefixes
## Why?

Some binaries like Temporal may be load in unstable versions because they use postfix like `priority`
