### PR TITLE
Increase memory limit and adjust error reporting settings

### DIFF
--- a/bin/dload
+++ b/bin/dload
@@ -9,9 +9,11 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\CommandLoader\FactoryCommandLoader;
 
 // Set timeout to 0 to prevent script from timing out
-set_time_limit(0);
+\set_time_limit(0);
+\ini_set('memory_limit', '2G');
+\error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT & ~E_NOTICE);
 
-(static function () {
+(static function (): void {
     $cwd = \getcwd();
 
     $possibleAutoloadPaths = [


### PR DESCRIPTION
## What was changed

Increase memory limit and adjust error reporting settings when dload is run though the entry script.

## Why?

1. To avoid deprecations if react/promise v2 is loaded on PHP 8.4
2. To increase memory limit that is 128m by default. Looks like symfony client memorizes downloaded data.
