### PR TITLE
Add ability to load `phar` archives

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -67,7 +67,7 @@ jobs:
       cancel-in-progress: true
       group: testing-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.php-version }}-${{ matrix.dependencies }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest
@@ -75,6 +75,7 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
         dependencies:
           - lowest
           - locked

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -88,7 +88,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           ini-values: error_reporting=E_ALL
-          coverage: xdebug
 
       - name: 🛠️ Setup problem matchers
         run: |

--- a/README.md
+++ b/README.md
@@ -38,57 +38,53 @@ composer require internal/dload -W
 [![License](https://img.shields.io/packagist/l/internal/dload.svg?style=flat-square)](LICENSE.md)
 [![Total DLoads](https://img.shields.io/packagist/dt/internal/dload.svg?style=flat-square)](https://packagist.org/packages/internal/dload/stats)
 
+## Quick Start
+
+1. **Initialize your project configuration**:
+
+```xml
+<?xml version="1.0"?>
+<dload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="vendor/internal/dload/dload.xsd"
+>
+   <actions>
+       <download software="rr" version="^2025.1.0"/>
+       <download software="temporal" version="^1.3"/>
+   </actions>
+</dload>
+```
+
+2. **Download configured software**:
+
+```bash
+./vendor/bin/dload get
+```
+
+3. **Integrate with Composer** (optional):
+   ```json
+   {
+       "scripts": {
+           "post-update-cmd": "dload get --no-interaction -v || echo can't dload binaries"
+       }
+   }
+   ```
+
 ## Command Line Usage
-
-DLoad offers three main commands:
-
-### List Available Software
-
-```bash
-# View all available software packages
-./vendor/bin/dload software
-```
-
-This displays a list of all registered software packages with their IDs, names, repository information, and descriptions.
-
-DLoad comes with a pre-configured list of popular tools and software packages ready for download.
-You can contribute to this list by submitting issues or pull requests to the DLoad repository.
-
-### Show Downloaded Software
-
-```bash
-# View all downloaded software
-./vendor/bin/dload show
-
-# Show detailed information about specific software
-./vendor/bin/dload show rr
-
-# Show all available software, including those not downloaded
-./vendor/bin/dload show --all
-```
-
-This command displays information about downloaded software.
 
 ### Download Software
 
 ```bash
-# Basic usage
-./vendor/bin/dload get rr
-
-# Download multiple packages
-./vendor/bin/dload get rr dolt temporal
-
-# Download with specific stability
-./vendor/bin/dload get rr --stability=beta
-
-# Use configuration from file (without specifying software)
+# Download from configuration file
 ./vendor/bin/dload get
 
-# Force download even if binary exists
-./vendor/bin/dload get rr --force
+# Download specific packages
+./vendor/bin/dload get rr temporal
+
+# Download with options
+./vendor/bin/dload get rr --stability=beta --force
 ```
 
-#### Download Command Options
+#### Download Options
 
 | Option | Description | Default |
 |--------|-------------|---------|
@@ -99,13 +95,25 @@ This command displays information about downloaded software.
 | `--config` | Path to configuration file | ./dload.xml |
 | `--force`, `-f` | Force download even if binary exists | false |
 
-## Project Configuration
+### View Software
 
-### Setting Up Your Project
+```bash
+# List available software packages
+./vendor/bin/dload software
 
-The `dload.xml` file in your project root is essential for automation. It defines the tools and assets required by your project, allowing for automatic initialization of development environments.
+# Show downloaded software
+./vendor/bin/dload show
 
-When a new developer joins your project, they can simply run `dload get` to download all necessary binaries and assets without manual configuration.
+# Show specific software details
+./vendor/bin/dload show rr
+
+# Show all software (downloaded and available)
+./vendor/bin/dload show --all
+```
+
+## Configuration Guide
+
+### Basic Configuration
 
 Create `dload.xml` in your project root:
 
@@ -113,261 +121,226 @@ Create `dload.xml` in your project root:
 <?xml version="1.0"?>
 <dload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/php-internal/dload/refs/heads/1.x/dload.xsd"
-       temp-dir="./runtime"
->
+       temp-dir="./runtime">
     <actions>
-        <download software="rr" version="^2.12.0" />
-        <download software="dolt" />
+        <download software="rr" version="^2025.1" />
         <download software="temporal" />
-        <download software="frontend" extract-path="frontend"/>
+        <download software="frontend" extract-path="frontend" />
     </actions>
 </dload>
 ```
 
-Then run:
+### Download Types
 
-```bash
-./vendor/bin/dload get
-```
+DLoad supports three download types that determine how assets are processed:
 
-### Configuration Options
-
-The `dload.xml` file supports several options:
-
-- **temp-dir**: Directory for temporary files during download (default: system temp dir)
-- **actions**: List of download actions to perform
-
-#### Download Action Options
-
-Each `<download>` action supports:
-
-- **software**: Name or alias of the software to download (required)
-- **version**: Target version using Composer versioning syntax (e.g., `^2.12.0`, `~1.0`, `1.2.3`)
-- **extract-path**: Directory where files will be extracted (useful for non-binary assets)
-
-The **version** attribute supports advanced constraints for targeting specific release types.
-You can use feature suffixes to target releases with custom tags like `^2.12.0-experimental` for experimental builds,
-or minimum-stability constraints to filter by release stability such as `^2.12.0@beta` for beta or more stable releases.
-
-**Feature Suffix Behavior**: When using feature suffix constraints (e.g., `^2.12.0-experimental`),
-the minimum stability is automatically set to `preview`, equivalent to writing `^2.12.0-experimental@preview`.
-This ensures that feature releases with preview stability or higher are included,
-while maintaining conservative defaults for production use.
-
-**Release Stability Parsing**: Regular releases without suffixes (e.g., `v2.1.0`) are treated as stable.
-However, releases with feature suffixes but no explicit stability marker (e.g., `v2.1.0-experimental`) are automatically parsed as `preview` stability,
-indicating they demonstrate functionality but are not production-ready.
-
-### Handling Different File Types
-
-DLoad handles both binary executables and regular files:
+#### Type Attribute
 
 ```xml
-<software name="my-app">
-    <!-- Binary executable that depends on OS/architecture -->
-    <binary name="app-cli" pattern="/^app-cli-.*/" />
-    
-    <!-- Regular file that works on any system -->
-    <file pattern="/^config.yml$/" />
+<!-- Explicit type specification -->
+<download software="psalm" type="phar" />        <!-- Download .phar without unpacking -->
+<download software="frontend" type="archive" />  <!-- Force archive extraction -->
+<download software="rr" type="binary" />         <!-- Binary-specific processing -->
+
+<!-- Automatic type handling (recommended) -->
+<download software="rr" />           <!-- Uses all available handlers -->
+<download software="frontend" />     <!-- Smart processing based on software config -->
+```
+
+#### Default Behavior (No Type Specified)
+
+When `type` is not specified, DLoad automatically uses all available handlers:
+
+- **Binary processing**: If software has `<binary>` section, performs binary presence and version checking
+- **Files processing**: If software has `<file>` section and asset is downloaded, processes files during unpacking
+- **Simple download**: If no sections exist, downloads asset without unpacking
+
+```xml
+<!-- registry list -->
+<software name="complex-tool">
+    <binary name="tool" pattern="/^tool-.*/" />
+    <file pattern="/^config\..*/" extract-path="config" />
 </software>
+
+<!-- actions list -->
+<!-- Uses both binary and files processing -->
+<download software="complex-tool" />
 ```
 
-### Automatic Binary Downloads with Composer Update
+#### Explicit Type Behaviors
 
-Integrate DLoad with Composer to automatically download required binaries whenever dependencies are updated.
-This ensures your team always has the necessary tools without manual intervention.
+| Type      | Behavior                                                     | Use Case                       |
+|-----------|--------------------------------------------------------------|--------------------------------|
+| `binary`  | Binary checking, version validation, executable permissions  | CLI tools, executables         |
+| `phar`    | Downloads `.phar` files as executables **without unpacking** | PHP tools like Psalm, PHPStan  |
+| `archive` | **Forces unpacking even for .phar files**                    | When you need archive contents |
 
-Add the following to your `composer.json`:
+> [!NOTE]
+> Use `type="phar"` for PHP tools that should remain as `.phar` files.
+> Using `type="archive"` will unpack even `.phar` archives.
 
-```json
-{
-    "scripts": {
-        "post-update-cmd": "dload get --no-interaction -v || echo can't dload binaries",
-        "get:binaries": "dload get --no-interaction --force -vv"
-    }
-}
+### Version Constraints
+
+Use Composer-style version constraints:
+
+```xml
+<actions>
+    <!-- Exact version -->
+    <download software="rr" version="2.12.3" />
+    
+    <!-- Range constraints -->
+    <download software="temporal" version="^1.20.0" />
+    <download software="dolt" version="~0.50.0" />
+    
+    <!-- Stability constraints -->
+    <download software="tool" version="^1.0.0@beta" />
+    
+    <!-- Feature releases (automatically sets preview stability) -->
+    <download software="experimental" version="^1.0.0-experimental" />
+</actions>
 ```
 
-This configuration:
+### Advanced Configuration Options
 
-- Automatically downloads required binaries after `composer update`
-- Provides a custom command `composer get:binaries` to force download all binaries with detailed output
+```xml
+<dload temp-dir="./runtime">
+    <actions>
+        <!-- Different extraction paths -->
+        <download software="frontend" extract-path="public/assets" />
+        <download software="config" extract-path="config" />
+        
+        <!-- Target different environments -->
+        <download software="prod-tool" version="^2.0.0@stable" />
+        <download software="dev-tool" version="^2.0.0@beta" />
+    </actions>
+</dload>
+```
 
 ## Custom Software Registry
 
-### Defining Custom Software
-
-Create your own software definitions:
+### Defining Software
 
 ```xml
-<?xml version="1.0"?>
-<dload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/php-internal/dload/refs/heads/1.x/dload.xsd"
->
+<dload>
     <registry overwrite="false">
-        <!-- Binary software example -->
-        <software name="RoadRunner" alias="rr"
+        <!-- Binary executable -->
+        <software name="RoadRunner" alias="rr" 
                   homepage="https://roadrunner.dev"
-                  description="High performant Application server">
+                  description="High performance Application server">
             <repository type="github" uri="roadrunner-server/roadrunner" asset-pattern="/^roadrunner-.*/" />
             <binary name="rr" pattern="/^roadrunner-.*/" />
         </software>
 
-        <!-- Non-binary files example -->
+        <!-- Archive with files -->
         <software name="frontend" description="Frontend assets">
-            <repository type="github"
-                        uri="my-org/frontend"
-                        asset-pattern="/^artifacts.*/"
-            />
+            <repository type="github" uri="my-org/frontend" asset-pattern="/^artifacts.*/" />
             <file pattern="/^.*\.js$/" />
             <file pattern="/^.*\.css$/" />
         </software>
 
-        <!-- Software with mixed file types -->
-        <software name="my-tool" description="Complete tool suite">
-            <repository type="github" uri="my-org/tool" />
-            <!-- Binary executables -->
-            <binary name="tool-cli" pattern="/^tool-cli.*/" />
-            <binary name="tool-worker" pattern="/^worker.*/" />
-            <!-- Configuration files -->
+        <!-- Mixed: binaries + files -->
+        <software name="development-suite" description="Complete development tools">
+            <repository type="github" uri="my-org/dev-tools" />
+            <binary name="cli-tool" pattern="/^cli-tool.*/" />
             <file pattern="/^config\.yml$/" extract-path="config" />
             <file pattern="/^templates\/.*/" extract-path="templates" />
+        </software>
+
+        <!-- PHAR tools -->
+        <software name="psalm" description="Static analysis tool">
+            <repository type="github" uri="vimeo/psalm" />
+            <binary name="psalm.phar" pattern="/^psalm\.phar$/" />
         </software>
     </registry>
 </dload>
 ```
 
-### Software Configuration Options
+### Software Elements
 
-Each `<software>` entry supports:
-
-- **name**: Display name (required)
-- **alias**: Short name for command line usage
-- **description**: Brief description
-- **homepage**: Website URL
-
-#### Repository Options
-
-The `<repository>` element configures where to download from:
-
+#### Repository Configuration
 - **type**: Currently supports "github"
 - **uri**: Repository path (e.g., "username/repo")
 - **asset-pattern**: Regex pattern to match release assets
 
-#### Binary Options
+#### Binary Elements
+- **name**: Binary name for reference
+- **pattern**: Regex pattern to match binary in assets
+- Automatically handles OS/architecture filtering
 
-The `<binary>` element defines executable files:
-
-- **name**: Binary name that will be referenced
-- **pattern**: Regex pattern to match the binary in release assets
-
-Binary files are OS and architecture specific. DLoad will automatically download the correct version for your system.
-
-#### File Options
-
-The `<file>` element defines non-binary files:
-
+#### File Elements  
 - **pattern**: Regex pattern to match files
-- **extract-path**: Optional subdirectory where files will be extracted
+- **extract-path**: Optional extraction directory
+- Works on any system (no OS/architecture filtering)
 
-File assets don't have OS/architecture restrictions and work on any system.
+## Use Cases
+
+### Development Environment Setup
+
+```bash
+# One-time setup for new developers
+composer install
+./vendor/bin/dload get
+```
+
+### CI/CD Integration
+
+```yaml
+# GitHub Actions
+- name: Download tools
+  run: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} ./vendor/bin/dload get
+```
+
+### Cross-Platform Teams
+
+Each developer gets the correct binaries for their system:
+
+```xml
+<actions>
+    <download software="rr" />        <!-- Linux binary for Linux, Windows .exe for Windows -->
+    <download software="temporal" />   <!-- macOS binary for macOS, etc. -->
+</actions>
+```
+
+### PHAR Tools Management
+
+```xml
+<actions>
+    <!-- Download as executable .phar files -->
+    <download software="psalm" type="phar" />
+    <download software="phpstan" type="phar" />
+    
+    <!-- Extract contents instead -->
+    <download software="psalm" type="archive" />  <!-- Unpacks psalm.phar -->
+</actions>
+```
+
+### Frontend Asset Distribution
+
+```xml
+<software name="ui-kit">
+    <repository type="github" uri="company/ui-components" />
+    <file pattern="/^dist\/.*/" extract-path="public/components" />
+</software>
+
+<actions>
+    <download software="ui-kit" type="archive" />
+</actions>
+```
 
 ## GitHub API Rate Limits
 
-To avoid GitHub API rate limits, use a personal access token:
+Use a personal access token to avoid rate limits:
 
 ```bash
 GITHUB_TOKEN=your_token_here ./vendor/bin/dload get
 ```
 
-You can add this to your CI/CD pipeline environment variables for automated downloads.
-
-## Use Cases
-
-### Local Development Environment Setup
-
-Automatically download required tools when setting up a development environment:
-
-```bash
-# Initialize project with all required tools
-composer install
-./vendor/bin/dload get
-```
-
-### CI/CD Pipeline Integration
-
-In your GitHub Actions workflow:
-
-```yaml
-steps:
-  - uses: actions/checkout@v2
-
-  - name: Setup PHP
-    uses: shivammathur/setup-php@v2
-    with:
-      php-version: '8.1'
-
-  - name: Install dependencies
-    run: composer install
-
-  - name: Download binary tools
-    run: |
-      GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} ./vendor/bin/dload get
-```
-
-### Cross-Platform Development Team
-
-Configure once, use everywhere:
-
-```xml
-<dload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/php-internal/dload/refs/heads/1.x/dload.xsd"
->
-    <actions>
-        <download software="rr" version="^2.12.0" />
-        <download software="temporal" />
-    </actions>
-</dload>
-```
-
-Each team member runs `./vendor/bin/dload get` and gets the correct binaries for their system (Windows, macOS, or Linux).
-
-### Distributed Frontend Assets
-
-Keep your frontend assets separate from your PHP repository:
-
-```xml
-<software name="frontend-bundle">
-    <repository type="github" uri="your-org/frontend-build" asset-pattern="/^dist.*/" />
-    <file pattern="/^.*$/" extract-path="public/assets" />
-</software>
-```
-
-### Advanced Development Workflows
-
-Target specific release types for different environments:
-
-```xml
-<dload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/php-internal/dload/refs/heads/1.x/dload.xsd"
->
-    <actions>
-        <!-- Production: stable releases only -->
-        <download software="rr" version="^2.12.0@stable" />
-        
-        <!-- Staging: beta releases for testing -->
-        <download software="temporal" version="^1.20.0@beta" />
-        
-        <!-- Development: experimental features (automatically sets minimum stability to preview) -->
-        <download software="dev-tool" version="^1.0.0-experimental" />
-        
-        <!-- Feature branch testing with explicit stability -->
-        <download software="app" version="^2.0.0-new-api@alpha" />
-    </actions>
-</dload>
-```
+Add to CI/CD environment variables for automated downloads.
 
 ## Contributing
 
-Contributions are welcome!
-Feel free to submit a Pull Request to add new software to the predefined list or improve the functionality of DLoad.
+Contributions welcome! Submit Pull Requests to:
+- Add new software to the predefined registry
+- Improve DLoad functionality  
+- Enhance documentation
+

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ composer require internal/dload -W
 ```
 
 3. **Integrate with Composer** (optional):
+
    ```json
    {
        "scripts": {
@@ -258,16 +259,19 @@ Use Composer-style version constraints:
 ### Software Elements
 
 #### Repository Configuration
+
 - **type**: Currently supports "github"
 - **uri**: Repository path (e.g., "username/repo")
 - **asset-pattern**: Regex pattern to match release assets
 
 #### Binary Elements
+
 - **name**: Binary name for reference
 - **pattern**: Regex pattern to match binary in assets
 - Automatically handles OS/architecture filtering
 
-#### File Elements  
+#### File Elements
+
 - **pattern**: Regex pattern to match files
 - **extract-path**: Optional extraction directory
 - Works on any system (no OS/architecture filtering)
@@ -340,7 +344,7 @@ Add to CI/CD environment variables for automated downloads.
 ## Contributing
 
 Contributions welcome! Submit Pull Requests to:
+
 - Add new software to the predefined registry
 - Improve DLoad functionality  
 - Enhance documentation
-

--- a/README.md
+++ b/README.md
@@ -42,33 +42,33 @@ composer require internal/dload -W
 
 1. **Initialize your project configuration**:
 
-```xml
-<?xml version="1.0"?>
-<dload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:noNamespaceSchemaLocation="vendor/internal/dload/dload.xsd"
->
-   <actions>
-       <download software="rr" version="^2025.1.0"/>
-       <download software="temporal" version="^1.3"/>
-   </actions>
-</dload>
-```
+    ```xml
+    <?xml version="1.0"?>
+    <dload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:noNamespaceSchemaLocation="vendor/internal/dload/dload.xsd"
+    >
+       <actions>
+           <download software="rr" version="^2025.1.0"/>
+           <download software="temporal" version="^1.3"/>
+       </actions>
+    </dload>
+    ```
 
 2. **Download configured software**:
 
-```bash
-./vendor/bin/dload get
-```
+    ```bash
+    ./vendor/bin/dload get
+    ```
 
 3. **Integrate with Composer** (optional):
 
-   ```json
-   {
-       "scripts": {
-           "post-update-cmd": "dload get --no-interaction -v || echo can't dload binaries"
-       }
-   }
-   ```
+    ```json
+    {
+        "scripts": {
+            "post-update-cmd": "dload get --no-interaction -v || echo can't dload binaries"
+        }
+    }
+    ```
 
 ## Command Line Usage
 

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         "php": ">=8.1",
         "composer/semver": "^3.4",
         "psr/container": "1 - 2",
-        "react/async": "3 - 4",
-        "react/promise": "2 - 3",
+        "react/async": "^3.2 || ^4.3",
+        "react/promise": "^2.10 || ^3.2",
         "symfony/console": "^6.4 || ^7",
-        "symfony/http-client": "4 - 7",
+        "symfony/http-client": "^4.4 || ^5.4 || ^6.4 || ^7",
         "yiisoft/injector": "^1.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -93,6 +93,10 @@
             "@putenv XDEBUG_MODE=coverage",
             "phpunit --color=always --testsuite=Arch"
         ],
+        "test:acc": [
+            "@putenv XDEBUG_MODE=coverage",
+            "phpunit --color=always --testsuite=Acceptance"
+        ],
         "test:cc": [
             "@putenv XDEBUG_MODE=coverage",
             "phpunit --coverage-clover=runtime/phpunit/logs/clover.xml --color=always"

--- a/composer.json
+++ b/composer.json
@@ -82,8 +82,7 @@
         "refactor": "rector process --config=rector.php",
         "refactor:ci": "rector process --config=rector.php --dry-run --ansi",
         "test": [
-            "@putenv XDEBUG_MODE=coverage",
-            "phpunit --color=always"
+            "phpunit --color=always --no-coverage"
         ],
         "test:unit": [
             "@putenv XDEBUG_MODE=coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -412,16 +412,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.20",
+            "version": "v6.4.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "2e4af9c952617cc3f9559ff706aee420a8464c36"
+                "reference": "7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/2e4af9c952617cc3f9559ff706aee420a8464c36",
-                "reference": "2e4af9c952617cc3f9559ff706aee420a8464c36",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3",
+                "reference": "7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3",
                 "shasum": ""
             },
             "require": {
@@ -486,7 +486,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.20"
+                "source": "https://github.com/symfony/console/tree/v6.4.22"
             },
             "funding": [
                 {
@@ -502,20 +502,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-03T17:16:38+00:00"
+            "time": "2025-05-07T07:05:04+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
                 "shasum": ""
             },
             "require": {
@@ -528,7 +528,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -553,7 +553,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -569,7 +569,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/http-client",
@@ -666,16 +666,16 @@
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.5.2",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "ee8d807ab20fcb51267fdace50fbe3494c31e645"
+                "reference": "75d7043853a42837e68111812f4d964b01e5101c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/ee8d807ab20fcb51267fdace50fbe3494c31e645",
-                "reference": "ee8d807ab20fcb51267fdace50fbe3494c31e645",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/75d7043853a42837e68111812f4d964b01e5101c",
+                "reference": "75d7043853a42837e68111812f4d964b01e5101c",
                 "shasum": ""
             },
             "require": {
@@ -688,7 +688,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -724,7 +724,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.5.2"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -740,11 +740,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-07T08:49:48+00:00"
+            "time": "2025-04-29T11:18:49+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -803,7 +803,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -823,7 +823,7 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
@@ -881,7 +881,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -901,7 +901,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -962,7 +962,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -982,19 +982,20 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
                 "shasum": ""
             },
             "require": {
+                "ext-iconv": "*",
                 "php": ">=7.2"
             },
             "provide": {
@@ -1042,7 +1043,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -1058,20 +1059,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2024-12-23T08:48:59+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0"
+                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
-                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
+                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
                 "shasum": ""
             },
             "require": {
@@ -1089,7 +1090,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -1125,7 +1126,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -1141,20 +1142,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2025-04-25T09:37:31+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.15",
+            "version": "v6.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f"
+                "reference": "73e2c6966a5aef1d4892873ed5322245295370c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f",
-                "reference": "73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f",
+                "url": "https://api.github.com/repos/symfony/string/zipball/73e2c6966a5aef1d4892873ed5322245295370c6",
+                "reference": "73e2c6966a5aef1d4892873ed5322245295370c6",
                 "shasum": ""
             },
             "require": {
@@ -1211,7 +1212,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.15"
+                "source": "https://github.com/symfony/string/tree/v6.4.21"
             },
             "funding": [
                 {
@@ -1227,7 +1228,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-13T13:31:12+00:00"
+            "time": "2025-04-18T15:23:29+00:00"
         },
         {
             "name": "yiisoft/injector",
@@ -2111,16 +2112,16 @@
         },
         {
             "name": "buggregator/trap",
-            "version": "1.13.12",
+            "version": "1.13.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/buggregator/trap.git",
-                "reference": "2a0a6060f7d312e5296a393a303d5867005ff296"
+                "reference": "2c08a25c77fc5aa5cde1a3ce9b0199306a3ee49a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/buggregator/trap/zipball/2a0a6060f7d312e5296a393a303d5867005ff296",
-                "reference": "2a0a6060f7d312e5296a393a303d5867005ff296",
+                "url": "https://api.github.com/repos/buggregator/trap/zipball/2c08a25c77fc5aa5cde1a3ce9b0199306a3ee49a",
+                "reference": "2c08a25c77fc5aa5cde1a3ce9b0199306a3ee49a",
                 "shasum": ""
             },
             "require": {
@@ -2197,7 +2198,7 @@
             ],
             "support": {
                 "issues": "https://github.com/buggregator/trap/issues",
-                "source": "https://github.com/buggregator/trap/tree/1.13.12"
+                "source": "https://github.com/buggregator/trap/tree/1.13.16"
             },
             "funding": [
                 {
@@ -2209,7 +2210,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-04-03T01:29:54+00:00"
+            "time": "2025-06-09T08:58:44+00:00"
         },
         {
             "name": "clue/ndjson-react",
@@ -3218,16 +3219,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.0",
+            "version": "1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
                 "shasum": ""
             },
             "require": {
@@ -3266,7 +3267,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
             },
             "funding": [
                 {
@@ -3274,7 +3275,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-12T12:17:51+00:00"
+            "time": "2025-04-29T12:36:36+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -3329,16 +3330,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.4.0",
+            "version": "v5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
+                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/ae59794362fe85e051a58ad36b289443f57be7a9",
+                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9",
                 "shasum": ""
             },
             "require": {
@@ -3381,9 +3382,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.5.0"
             },
-            "time": "2024-12-30T11:07:19+00:00"
+            "time": "2025-05-31T08:24:38+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -3790,16 +3791,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.1",
+            "version": "5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8"
+                "reference": "92dde6a5919e34835c506ac8c523ef095a95ed62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
-                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/92dde6a5919e34835c506ac8c523ef095a95ed62",
+                "reference": "92dde6a5919e34835c506ac8c523ef095a95ed62",
                 "shasum": ""
             },
             "require": {
@@ -3848,9 +3849,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.1"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.2"
             },
-            "time": "2024-12-07T09:39:29+00:00"
+            "time": "2025-04-13T19:20:35+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -4280,16 +4281,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.45",
+            "version": "10.5.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "bd68a781d8e30348bc297449f5234b3458267ae8"
+                "reference": "8080be387a5be380dda48c6f41cee4a13aadab3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bd68a781d8e30348bc297449f5234b3458267ae8",
-                "reference": "bd68a781d8e30348bc297449f5234b3458267ae8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8080be387a5be380dda48c6f41cee4a13aadab3d",
+                "reference": "8080be387a5be380dda48c6f41cee4a13aadab3d",
                 "shasum": ""
             },
             "require": {
@@ -4299,7 +4300,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.1",
+                "myclabs/deep-copy": "^1.13.1",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
@@ -4361,7 +4362,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.45"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.46"
             },
             "funding": [
                 {
@@ -4373,11 +4374,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-06T16:08:12+00:00"
+            "time": "2025-05-02T06:46:24+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -6112,16 +6121,16 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f"
+                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7642f5e970b672283b7823222ae8ef8bbc160b9f",
-                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
+                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
                 "shasum": ""
             },
             "require": {
@@ -6135,7 +6144,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -6168,7 +6177,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -6184,7 +6193,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -6385,16 +6394,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
                 "shasum": ""
             },
             "require": {
@@ -6445,7 +6454,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -6461,11 +6470,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2025-01-02T08:10:11+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
@@ -6521,7 +6530,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -6541,16 +6550,16 @@
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "e5493eb51311ab0b1cc2243416613f06ed8f18bd"
+                "reference": "000df7860439609837bbe28670b0be15783b7fbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/e5493eb51311ab0b1cc2243416613f06ed8f18bd",
-                "reference": "e5493eb51311ab0b1cc2243416613f06ed8f18bd",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/000df7860439609837bbe28670b0be15783b7fbf",
+                "reference": "000df7860439609837bbe28670b0be15783b7fbf",
                 "shasum": ""
             },
             "require": {
@@ -6597,7 +6606,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -6613,7 +6622,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T12:04:04+00:00"
+            "time": "2025-02-20T12:04:08+00:00"
         },
         {
             "name": "symfony/process",
@@ -6740,16 +6749,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.4.18",
+            "version": "v6.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "4ad10cf8b020e77ba665305bb7804389884b4837"
+                "reference": "22560f80c0c5cd58cc0bcaf73455ffd81eb380d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/4ad10cf8b020e77ba665305bb7804389884b4837",
-                "reference": "4ad10cf8b020e77ba665305bb7804389884b4837",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/22560f80c0c5cd58cc0bcaf73455ffd81eb380d5",
+                "reference": "22560f80c0c5cd58cc0bcaf73455ffd81eb380d5",
                 "shasum": ""
             },
             "require": {
@@ -6805,7 +6814,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.4.18"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.4.21"
             },
             "funding": [
                 {
@@ -6821,27 +6830,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-17T11:26:11+00:00"
+            "time": "2025-04-09T07:34:50+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",
-            "version": "0.8.4",
+            "version": "0.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ta-tikoma/phpunit-architecture-test.git",
-                "reference": "89f0dea1cb0f0d5744d3ec1764a286af5e006636"
+                "reference": "cf6fb197b676ba716837c886baca842e4db29005"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/89f0dea1cb0f0d5744d3ec1764a286af5e006636",
-                "reference": "89f0dea1cb0f0d5744d3ec1764a286af5e006636",
+                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/cf6fb197b676ba716837c886baca842e4db29005",
+                "reference": "cf6fb197b676ba716837c886baca842e4db29005",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18.0 || ^5.0.0",
                 "php": "^8.1.0",
                 "phpdocumentor/reflection-docblock": "^5.3.0",
-                "phpunit/phpunit": "^10.5.5  || ^11.0.0",
+                "phpunit/phpunit": "^10.5.5  || ^11.0.0 || ^12.0.0",
                 "symfony/finder": "^6.4.0 || ^7.0.0"
             },
             "require-dev": {
@@ -6878,9 +6887,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ta-tikoma/phpunit-architecture-test/issues",
-                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.4"
+                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.5"
             },
-            "time": "2024-01-05T14:10:56+00:00"
+            "time": "2025-04-20T20:23:40+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -6934,16 +6943,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.10.0",
+            "version": "6.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "9c0add4eb88d4b169ac04acb7c679918cbb9c252"
+                "reference": "cf420941d061a57050b6c468ef2c778faf40aee2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/9c0add4eb88d4b169ac04acb7c679918cbb9c252",
-                "reference": "9c0add4eb88d4b169ac04acb7c679918cbb9c252",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/cf420941d061a57050b6c468ef2c778faf40aee2",
+                "reference": "cf420941d061a57050b6c468ef2c778faf40aee2",
                 "shasum": ""
             },
             "require": {
@@ -7048,7 +7057,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-03-31T10:12:50+00:00"
+            "time": "2025-05-28T12:52:06+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc005329bb92ed657b163d9f228108e0",
+    "content-hash": "bd54f3ca4ed9da56e4b001be4b195759",
     "packages": [
         {
             "name": "composer/semver",

--- a/dload.xml
+++ b/dload.xml
@@ -26,8 +26,5 @@
             />
             <file pattern="/^.*$/"/>
         </software>
-        <software name="trap">
-            <repository type="github" uri="buggregator/trap" />
-        </software>
     </registry>
 </dload>

--- a/dload.xml
+++ b/dload.xml
@@ -10,6 +10,7 @@
         <download software="dolt" />
         <download software="temporal" version-path="composer.json@require.temporal/sdk" />
         <download software="frontend" extract-path="frontend"/>
+        <download software="trap" format="phar" version="^1.1" />
     </actions>
     <registry overwrite="false">
         <software name="RoadRunner" alias="rr"
@@ -24,6 +25,9 @@
                         asset-pattern="/^artifacts.*/"
             />
             <file pattern="/^.*$/"/>
+        </software>
+        <software name="trap">
+            <repository type="github" uri="buggregator/trap" />
         </software>
     </registry>
 </dload>

--- a/dload.xsd
+++ b/dload.xsd
@@ -1,166 +1,176 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
-  <!-- Root element -->
-  <xs:element name="dload">
-    <xs:annotation>
-      <xs:documentation>DLoad configuration for downloading and managing binary artifacts</xs:documentation>
-    </xs:annotation>
-    <xs:complexType>
-      <xs:sequence>
-        <!-- Actions container -->
-        <xs:element name="actions" minOccurs="0" maxOccurs="1">
-          <xs:annotation>
-            <xs:documentation>Container for download actions</xs:documentation>
-          </xs:annotation>
-          <xs:complexType>
-            <xs:sequence>
-              <xs:element name="download" minOccurs="0" maxOccurs="unbounded">
-                <xs:annotation>
-                  <xs:documentation>Defines a software package to download</xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                  <xs:attribute name="software" type="xs:string" use="required">
-                    <xs:annotation>
-                      <xs:documentation>Software identifier to download</xs:documentation>
-                    </xs:annotation>
-                  </xs:attribute>
-                  <xs:attribute name="version" type="xs:string">
-                    <xs:annotation>
-                      <xs:documentation>Version constraint (composer-style)</xs:documentation>
-                    </xs:annotation>
-                  </xs:attribute>
-                  <xs:attribute name="version-path" type="xs:string">
-                    <xs:annotation>
-                      <xs:documentation>Path to extract version from (e.g. composer.json@require.package/name)</xs:documentation>
-                    </xs:annotation>
-                  </xs:attribute>
-                  <xs:attribute name="extract-path" type="xs:string">
-                    <xs:annotation>
-                      <xs:documentation>Custom path where to unpack downloaded asset</xs:documentation>
-                    </xs:annotation>
-                  </xs:attribute>
-                </xs:complexType>
-              </xs:element>
-            </xs:sequence>
-          </xs:complexType>
-        </xs:element>
-        
-        <!-- Registry container -->
-        <xs:element name="registry" minOccurs="0" maxOccurs="1">
-          <xs:annotation>
-            <xs:documentation>Custom software registry configuration</xs:documentation>
-          </xs:annotation>
-          <xs:complexType>
-            <xs:sequence>
-              <xs:element name="software" minOccurs="0" maxOccurs="unbounded">
-                <xs:annotation>
-                  <xs:documentation>Software configuration entity</xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                  <xs:sequence>
-                    <xs:element name="repository" minOccurs="0" maxOccurs="unbounded">
-                      <xs:annotation>
-                        <xs:documentation>Repository configuration</xs:documentation>
-                      </xs:annotation>
-                      <xs:complexType>
-                        <xs:attribute name="type" type="xs:string" default="github">
-                          <xs:annotation>
-                            <xs:documentation>Repository type identifier</xs:documentation>
-                          </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="uri" type="xs:string" use="required">
-                          <xs:annotation>
-                            <xs:documentation>Repository URI identifier</xs:documentation>
-                          </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="asset-pattern" type="xs:string" default="/^.*$/">
-                          <xs:annotation>
-                            <xs:documentation>Regular expression pattern to match assets</xs:documentation>
-                          </xs:annotation>
-                        </xs:attribute>
-                      </xs:complexType>
-                    </xs:element>
-                    <xs:element name="binary" minOccurs="0" maxOccurs="unbounded">
-                      <xs:annotation>
-                        <xs:documentation>Binary configuration</xs:documentation>
-                      </xs:annotation>
-                      <xs:complexType>
-                        <xs:attribute name="name" type="xs:string" use="required">
-                          <xs:annotation>
-                            <xs:documentation>Binary executable name</xs:documentation>
-                          </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="pattern" type="xs:string">
-                          <xs:annotation>
-                            <xs:documentation>Regular expression pattern to match binary file during extraction</xs:documentation>
-                          </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="version-command" type="xs:string">
-                          <xs:annotation>
-                            <xs:documentation>Command argument to check binary version (e.g. "--version")</xs:documentation>
-                          </xs:annotation>
-                        </xs:attribute>
-                      </xs:complexType>
-                    </xs:element>
-                    <xs:element name="file" minOccurs="0" maxOccurs="unbounded">
-                      <xs:annotation>
-                        <xs:documentation>File configuration</xs:documentation>
-                      </xs:annotation>
-                      <xs:complexType>
-                        <xs:attribute name="pattern" type="xs:string" default="/^.*$/">
-                          <xs:annotation>
-                            <xs:documentation>Regular expression pattern to match files</xs:documentation>
-                          </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="rename" type="xs:string">
-                          <xs:annotation>
-                            <xs:documentation>Rename found file to this value with the same extension</xs:documentation>
-                          </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="extract-path" type="xs:string">
-                          <xs:annotation>
-                            <xs:documentation>Directory where to extract files</xs:documentation>
-                          </xs:annotation>
-                        </xs:attribute>
-                      </xs:complexType>
-                    </xs:element>
-                  </xs:sequence>
-                  <xs:attribute name="name" type="xs:string" use="required">
-                    <xs:annotation>
-                      <xs:documentation>Software package name</xs:documentation>
-                    </xs:annotation>
-                  </xs:attribute>
-                  <xs:attribute name="alias" type="xs:string">
-                    <xs:annotation>
-                      <xs:documentation>CLI command alias</xs:documentation>
-                    </xs:annotation>
-                  </xs:attribute>
-                  <xs:attribute name="homepage" type="xs:string">
-                    <xs:annotation>
-                      <xs:documentation>Official software homepage URL</xs:documentation>
-                    </xs:annotation>
-                  </xs:attribute>
-                  <xs:attribute name="description" type="xs:string">
-                    <xs:annotation>
-                      <xs:documentation>Short description of the software</xs:documentation>
-                    </xs:annotation>
-                  </xs:attribute>
-                </xs:complexType>
-              </xs:element>
-            </xs:sequence>
-            <xs:attribute name="overwrite" type="xs:boolean" default="false">
-              <xs:annotation>
-                <xs:documentation>Replace the built-in software collection with custom ones</xs:documentation>
-              </xs:annotation>
-            </xs:attribute>
-          </xs:complexType>
-        </xs:element>
-      </xs:sequence>
-      <xs:attribute name="temp-dir" type="xs:string">
+    <!-- Root element -->
+    <xs:element name="dload">
         <xs:annotation>
-          <xs:documentation>Temporary directory for downloads</xs:documentation>
+            <xs:documentation>DLoad configuration for downloading and managing binary artifacts</xs:documentation>
         </xs:annotation>
-      </xs:attribute>
-    </xs:complexType>
-  </xs:element>
+        <xs:complexType>
+            <xs:sequence>
+                <!-- Actions container -->
+                <xs:element name="actions" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Container for download actions</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="download" minOccurs="0" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:documentation>Defines a software package to download</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:attribute name="software" type="xs:string" use="required">
+                                        <xs:annotation>
+                                            <xs:documentation>Software identifier to download</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="version" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Version constraint using Composer-style syntax with optional feature suffixes
+                                                and stability requirements. If not specified, latest stable version is used.
+
+                                                Examples:
+                                                • "^2.12.0" - Caret constraint
+                                                • "~1.0.0" - Tilde constraint
+                                                • "^2.12.0-feature" - With feature suffix
+                                                • "^2.12.0@beta" - With explicit stability
+                                                • "^2.12.0-hotfix@rc" - Combined feature and stability
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="version-path" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>Path to extract version from (e.g. composer.json@require.package/name)</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="extract-path" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>Custom path where to unpack downloaded asset</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+
+                <!-- Registry container -->
+                <xs:element name="registry" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Custom software registry configuration</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="software" minOccurs="0" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:documentation>Software configuration entity</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="repository" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:annotation>
+                                                <xs:documentation>Repository configuration</xs:documentation>
+                                            </xs:annotation>
+                                            <xs:complexType>
+                                                <xs:attribute name="type" type="xs:string" default="github">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Repository type identifier</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="uri" type="xs:string" use="required">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Repository URI identifier</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="asset-pattern" type="xs:string" default="/^.*$/">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Regular expression pattern to match assets</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                            </xs:complexType>
+                                        </xs:element>
+                                        <xs:element name="binary" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:annotation>
+                                                <xs:documentation>Binary configuration</xs:documentation>
+                                            </xs:annotation>
+                                            <xs:complexType>
+                                                <xs:attribute name="name" type="xs:string" use="required">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Binary executable name</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="pattern" type="xs:string">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Regular expression pattern to match binary file during extraction</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="version-command" type="xs:string">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Command argument to check binary version (e.g. "--version")</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                            </xs:complexType>
+                                        </xs:element>
+                                        <xs:element name="file" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:annotation>
+                                                <xs:documentation>File configuration</xs:documentation>
+                                            </xs:annotation>
+                                            <xs:complexType>
+                                                <xs:attribute name="pattern" type="xs:string" default="/^.*$/">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Regular expression pattern to match files</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="rename" type="xs:string">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Rename found file to this value with the same extension</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="extract-path" type="xs:string">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Directory where to extract files</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                    <xs:attribute name="name" type="xs:string" use="required">
+                                        <xs:annotation>
+                                            <xs:documentation>Software package name</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="alias" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>CLI command alias</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="homepage" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>Official software homepage URL</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="description" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>Short description of the software</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="overwrite" type="xs:boolean" default="false">
+                            <xs:annotation>
+                                <xs:documentation>Replace the built-in software collection with custom ones</xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+            <xs:attribute name="temp-dir" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>Temporary directory for downloads</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
 </xs:schema>

--- a/dload.xsd
+++ b/dload.xsd
@@ -49,6 +49,11 @@
                                             <xs:documentation>Custom path where to unpack downloaded asset</xs:documentation>
                                         </xs:annotation>
                                     </xs:attribute>
+                                    <xs:attribute name="format" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>Preferred file format for download (e.g., "phar", "tar.gz", "zip"). When specified, only assets matching this format will be considered during download.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
                                 </xs:complexType>
                             </xs:element>
                         </xs:sequence>

--- a/dload.xsd
+++ b/dload.xsd
@@ -49,10 +49,17 @@
                                             <xs:documentation>Custom path where to unpack downloaded asset</xs:documentation>
                                         </xs:annotation>
                                     </xs:attribute>
-                                    <xs:attribute name="format" type="xs:string">
+                                    <xs:attribute name="type">
                                         <xs:annotation>
-                                            <xs:documentation>Preferred file format for download (e.g., "phar", "tar.gz", "zip"). When specified, only assets matching this format will be considered during download.</xs:documentation>
+                                            <xs:documentation>Download type determining how the asset is processed: binary (executable from archive), phar (PHP archive, no extraction), archive (extract all contents)</xs:documentation>
                                         </xs:annotation>
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:enumeration value="binary"/>
+                                                <xs:enumeration value="archive"/>
+                                                <xs:enumeration value="phar"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
                                     </xs:attribute>
                                 </xs:complexType>
                             </xs:element>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,12 +6,14 @@
          cacheResultFile="runtime/phpunit/result.cache"
          failOnWarning="true"
          failOnRisky="true"
-         executionOrder="random"
          stderr="true"
          beStrictAboutOutputDuringTests="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
 >
     <testsuites>
+        <testsuite name="Acceptance">
+            <directory>tests/Acceptance</directory>
+        </testsuite>
         <testsuite name="Unit">
             <directory>tests/Unit</directory>
         </testsuite>

--- a/src/DLoad.php
+++ b/src/DLoad.php
@@ -183,7 +183,7 @@ final class DLoad
             $fileInfo = $downloadResult->file;
 
             // Create a copy of the files list with binary included if necessary
-            $files = $this->filesToExtract($software);
+            $files = $this->filesToExtract($software, $action);
 
             // Create destination directory if it doesn't exist
             $path = $this->getDestinationPath($action);
@@ -287,8 +287,13 @@ final class DLoad
     /**
      * @return list<File>
      */
-    private function filesToExtract(Software $software): array
+    private function filesToExtract(Software $software, DownloadConfig $action): array
     {
+        // Don't extract files for Phar actions
+        if ($action->type === Type::Phar) {
+            return [];
+        }
+
         $files = $software->files;
         if ($software->binary !== null) {
             $binary = new File();

--- a/src/DLoad.php
+++ b/src/DLoad.php
@@ -7,6 +7,7 @@ namespace Internal\DLoad;
 use Internal\DLoad\Module\Archive\ArchiveFactory;
 use Internal\DLoad\Module\Binary\BinaryProvider;
 use Internal\DLoad\Module\Common\Config\Action\Download as DownloadConfig;
+use Internal\DLoad\Module\Common\Config\Action\Type;
 use Internal\DLoad\Module\Common\Config\Embed\File;
 use Internal\DLoad\Module\Common\Config\Embed\Software;
 use Internal\DLoad\Module\Common\FileSystem\Path;
@@ -75,8 +76,9 @@ final class DLoad
 
         // Check if binary already exists and satisfies version constraint
         $destinationPath = $this->getDestinationPath($action);
+        $type = $action->type;
 
-        if (!$force && $software->binary !== null) {
+        if (!$force && ($type === null || $type === Type::Binary) && $software->binary !== null) {
             // Check different constraints
             $binary = $this->binaryProvider->getBinary($destinationPath, $software->binary);
 

--- a/src/Module/Archive/Internal/NullArchive.php
+++ b/src/Module/Archive/Internal/NullArchive.php
@@ -49,10 +49,7 @@ final class NullArchive extends Archive
             $sourcePath = $this->file->getRealPath() ?: $this->file->getPathname();
             $destPath = $fileTo->getRealPath() ?: $fileTo->getPathname();
 
-            \copy(
-                $sourcePath,
-                $destPath,
-            );
+            \copy($sourcePath, $destPath);
         }
     }
 }

--- a/src/Module/Common/Config/Action/Download.php
+++ b/src/Module/Common/Config/Action/Download.php
@@ -32,9 +32,9 @@ final class Download
     #[XPath('@extract-path')]
     public ?string $extractPath = null;
 
-    /** @var non-empty-string|null $format Preferred file format for download (e.g., "phar", "tar.gz", "zip") */
-    #[XPath('@format')]
-    public ?string $format = null;
+    /** @var non-empty-string|null $type Download type determining processing behavior (binary, archive, phar) */
+    #[XPath('@type')]
+    public ?string $type = null;
 
     /**
      * Creates a download action from a software identifier.

--- a/src/Module/Common/Config/Action/Download.php
+++ b/src/Module/Common/Config/Action/Download.php
@@ -32,9 +32,9 @@ final class Download
     #[XPath('@extract-path')]
     public ?string $extractPath = null;
 
-    /** @var non-empty-string|null $type Download type determining processing behavior (binary, archive, phar) */
+    /** @var Type|null $type Download type determining processing behavior (binary, archive, phar) */
     #[XPath('@type')]
-    public ?string $type = null;
+    public ?Type $type = null;
 
     /**
      * Creates a download action from a software identifier.

--- a/src/Module/Common/Config/Action/Download.php
+++ b/src/Module/Common/Config/Action/Download.php
@@ -32,6 +32,10 @@ final class Download
     #[XPath('@extract-path')]
     public ?string $extractPath = null;
 
+    /** @var non-empty-string|null $format Preferred file format for download (e.g., "phar", "tar.gz", "zip") */
+    #[XPath('@format')]
+    public ?string $format = null;
+
     /**
      * Creates a download action from a software identifier.
      *

--- a/src/Module/Common/Config/Action/Type.php
+++ b/src/Module/Common/Config/Action/Type.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\DLoad\Module\Common\Config\Action;
+
+/**
+ * Download action type enumeration.
+ *
+ * Defines the processing behavior for downloaded assets based on their intended use.
+ * Each type determines how the asset is filtered, downloaded, and post-processed.
+ */
+enum Type: string
+{
+    /**
+     * Binary executable type.
+     *
+     * Downloads executable binaries that may be extracted from archives.
+     * Performs version checking, sets executable permissions, and handles
+     * binary extraction from compressed archives when needed.
+     */
+    case Binary = 'binary';
+
+    /**
+     * Archive extraction type.
+     *
+     * Downloads and extracts entire archive contents to specified directory.
+     * Used for distributing multiple files, documentation, or project assets.
+     */
+    case Archive = 'archive';
+
+    /**
+     * PHP Archive (PHAR) type.
+     *
+     * Downloads PHAR files as self-contained PHP executables.
+     * Treats PHAR as a binary but with PHP-specific filtering and no extraction.
+     */
+    case Phar = 'phar';
+}

--- a/src/Module/Common/Config/Embed/File.php
+++ b/src/Module/Common/Config/Embed/File.php
@@ -37,6 +37,12 @@ final class File
     public string $pattern = '/^.*$/';
 
     /**
+     * @var int|null $chmod Optional file permissions to set after extraction
+     *      If null, no permissions will be changed.
+     */
+    public ?int $chmod = null;
+
+    /**
      * Creates a File configuration from an array.
      *
      * @param FileArray $fileArray Configuration array

--- a/src/Module/Common/Internal/Injection/ConfigLoader.php
+++ b/src/Module/Common/Internal/Injection/ConfigLoader.php
@@ -114,6 +114,14 @@ final class ConfigLoader
                         },
                         default => $value,
                     },
+                    \enum_exists($type->getName()) => (static function (mixed $value) use ($type): ?\BackedEnum {
+                        /** @var class-string<\BackedEnum> $class */
+                        $class = $type->getName();
+                        // Get Enum values type
+                        $cases = (new \ReflectionEnum($class))->getCases();
+                        $value = \is_int($cases[0]->getBackingValue()) ? (int) $value : (string) $value;
+                        return $class::from($value);
+                    })($value),
                     default => $value,
                 };
 

--- a/src/Module/Downloader/Downloader.php
+++ b/src/Module/Downloader/Downloader.php
@@ -186,11 +186,14 @@ final class Downloader
      */
     private function processRelease(DownloadContext $context): \Closure
     {
-        return fn(): AssetInterface => $context->software->binary !== null
+        return fn(): AssetInterface => match (true) {
+            // Phar assets usually don't depend on OS or architecture, so we can use gradual filtering
+            $context->actionConfig->type === Type::Phar => $this->findAssetWithGradualFiltering($context),
             // Use strict filtering when binary configuration exists
-            ? $this->findAssetWithStrictFiltering($context)
+            $context->software->binary !== null => $this->findAssetWithStrictFiltering($context),
             // Use gradual filtering when no binary configuration exists
-            : $this->findAssetWithGradualFiltering($context);
+            default => $this->findAssetWithGradualFiltering($context),
+        };
     }
 
     /**

--- a/src/Module/Downloader/Downloader.php
+++ b/src/Module/Downloader/Downloader.php
@@ -7,7 +7,6 @@ namespace Internal\DLoad\Module\Downloader;
 use Internal\DLoad\Module\Archive\ArchiveFactory;
 use Internal\DLoad\Module\Common\Architecture;
 use Internal\DLoad\Module\Common\Config\Action\Download;
-use Internal\DLoad\Module\Common\Config\Action\Download;
 use Internal\DLoad\Module\Common\Config\Action\Download as DownloadConfig;
 use Internal\DLoad\Module\Common\Config\Action\Type;
 use Internal\DLoad\Module\Common\Config\Downloader as DownloaderConfig;
@@ -435,9 +434,9 @@ final class Downloader
      */
     private function addFormatFilter(AssetsCollection $collection, Download $actionOptions): AssetsCollection
     {
-        $actionType = Type::tryFrom($actionOptions->type);
-        return match ($actionType) {
+        return match ($actionOptions->type) {
             Type::Phar => $collection->whereFileExtensions(['phar']),
+            Type::Archive => $collection->whereFileExtensions($this->archiveService->getSupportedExtensions()),
             default => $collection,
         };
     }

--- a/src/Module/Downloader/Downloader.php
+++ b/src/Module/Downloader/Downloader.php
@@ -205,6 +205,11 @@ final class Downloader
             ->whereArchitecture($this->architecture)
             ->whereNameMatches($context->repoConfig->assetPattern);
 
+        // Apply format filter if specified
+        if ($context->actionConfig->format !== null) {
+            $assetsCollection = $assetsCollection->whereFormat($context->actionConfig->format);
+        }
+
         /** @var AssetInterface[] $allAssets */
         $allAssets = $assetsCollection->toArray();
         $this->logger->debug('%d matching assets found.', \count($allAssets));
@@ -228,6 +233,12 @@ final class Downloader
     {
         $assetsCollection = $context->release->getAssets()
             ->whereNameMatches($context->repoConfig->assetPattern);
+        
+        // Apply format filter if specified
+        if ($context->actionConfig->format !== null) {
+            $assetsCollection = $assetsCollection->whereFormat($context->actionConfig->format);
+        }
+
         $supportedExtensions = $this->archiveService->getSupportedExtensions();
 
         if (\count($assetsCollection) === 0) {

--- a/src/Module/Repository/Collection/AssetsCollection.php
+++ b/src/Module/Repository/Collection/AssetsCollection.php
@@ -95,6 +95,23 @@ final class AssetsCollection extends Collection
     }
 
     /**
+     * Filters assets to include only those matching the specified format.
+     *
+     * @param non-empty-string $format Required format (e.g., "phar", "tar.gz", "zip")
+     * @return self New filtered collection
+     */
+    public function whereFormat(string $format): self
+    {
+        return $this->filter(
+            static function (AssetInterface $asset) use ($format): bool {
+                $assetName = \strtolower($asset->getName());
+                $normalizedFormat = \strtolower($format);
+                return \str_ends_with($assetName, '.' . $normalizedFormat);
+            },
+        );
+    }
+
+    /**
      * Filters assets to include only those with names matching the given regex pattern.
      *
      * @param non-empty-string $pattern Regular expression pattern

--- a/src/Module/Repository/Collection/AssetsCollection.php
+++ b/src/Module/Repository/Collection/AssetsCollection.php
@@ -95,23 +95,6 @@ final class AssetsCollection extends Collection
     }
 
     /**
-     * Filters assets to include only those matching the specified format.
-     *
-     * @param non-empty-string $format Required format (e.g., "phar", "tar.gz", "zip")
-     * @return self New filtered collection
-     */
-    public function whereFormat(string $format): self
-    {
-        return $this->filter(
-            static function (AssetInterface $asset) use ($format): bool {
-                $assetName = \strtolower($asset->getName());
-                $normalizedFormat = \strtolower($format);
-                return \str_ends_with($assetName, '.' . $normalizedFormat);
-            },
-        );
-    }
-
-    /**
      * Filters assets to include only those with names matching the given regex pattern.
      *
      * @param non-empty-string $pattern Regular expression pattern

--- a/tests/Acceptance/DLoadTest.php
+++ b/tests/Acceptance/DLoadTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\DLoad\Tests\Acceptance;
+
+use Internal\DLoad\Bootstrap;
+use Internal\DLoad\DLoad;
+use Internal\DLoad\Module\Common\Config\Action\Download as DownloadConfig;
+use Internal\DLoad\Service\Logger;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\StyleInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Acceptance tests for DLoad class.
+ *
+ * Tests the complete download workflow using real repositories and file extraction.
+ * Requires internet connectivity to download actual software packages.
+ */
+#[CoversClass(DLoad::class)]
+final class DLoadTest extends TestCase
+{
+    private string $testRuntimeDir;
+    private string $tempDir;
+    private string $destinationDir;
+    private DLoad $dload;
+
+    public function testDownloadsTrapPharSuccessfully(): void
+    {
+        // Arrange
+        $downloadConfig = new DownloadConfig();
+        $downloadConfig->software = 'trap';
+        $downloadConfig->version = '^1.13';
+        $downloadConfig->format = 'phar';
+        $downloadConfig->extractPath = $this->destinationDir;
+
+        // Act
+        $this->dload->addTask($downloadConfig);
+        $this->dload->run();
+
+        // Assert - Check that trap.phar was downloaded and extracted
+        $expectedPharPath = $this->destinationDir . DIRECTORY_SEPARATOR . 'trap.phar';
+        self::assertFileExists($expectedPharPath, 'Trap PHAR should be downloaded to destination directory');
+
+        // Verify the file is a valid PHAR
+        self::assertGreaterThan(1024, \filesize($expectedPharPath), 'Downloaded PHAR should have substantial size');
+
+        // Verify file permissions (should be executable)
+        if (PHP_OS_FAMILY !== 'Windows') {
+            self::assertTrue(\is_executable($expectedPharPath), 'PHAR file should be executable');
+        }
+    }
+
+    protected function setUp(): void
+    {
+        // Set up test directory structure
+        $projectRoot = \dirname(__DIR__, 2);
+        $this->testRuntimeDir = $projectRoot . '/runtime/tests/acceptance';
+        $this->tempDir = $this->testRuntimeDir . '/temp';
+        $this->destinationDir = $this->testRuntimeDir;
+
+        // Initialize DLoad through Bootstrap
+        $container = Bootstrap::init()
+            ->withConfig(
+                $this->createTrapXmlConfig(),
+                [],
+                [],
+                \getenv(),
+            )
+            ->finish();
+        $container->set($input = new ArgvInput(), InputInterface::class);
+        $container->set($output = new BufferedOutput(), OutputInterface::class);
+        $container->set(new SymfonyStyle($input, $output), StyleInterface::class);
+        $container->set(new Logger($output));
+
+        $this->dload = $container->get(DLoad::class);
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up test directories
+        if (\is_dir($this->testRuntimeDir)) {
+            $this->removeDirectory($this->testRuntimeDir);
+        }
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private function createTrapXmlConfig(): string
+    {
+        return <<<XML
+            <?xml version="1.0"?>
+            <dload temp-dir="{$this->tempDir}" >
+                <registry overwrite="false">
+                    <software name="trap">
+                        <repository type="github" uri="buggregator/trap"
+                            asset-pattern="/^trap\..+$/"
+                        />
+                    </software>
+                </registry>
+            </dload>
+            XML;
+
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!\is_dir($dir)) {
+            return;
+        }
+
+        $files = \scandir($dir);
+        foreach ($files as $file) {
+            if ($file === '.' || $file === '..') {
+                continue;
+            }
+
+            $path = $dir . DIRECTORY_SEPARATOR . $file;
+            if (\is_dir($path)) {
+                $this->removeDirectory($path);
+            } else {
+                \unlink($path);
+            }
+        }
+
+        \rmdir($dir);
+    }
+}

--- a/tests/Acceptance/DLoadTest.php
+++ b/tests/Acceptance/DLoadTest.php
@@ -7,6 +7,7 @@ namespace Internal\DLoad\Tests\Acceptance;
 use Internal\DLoad\Bootstrap;
 use Internal\DLoad\DLoad;
 use Internal\DLoad\Module\Common\Config\Action\Download as DownloadConfig;
+use Internal\DLoad\Module\Common\Config\Action\Type;
 use Internal\DLoad\Service\Logger;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -37,7 +38,7 @@ final class DLoadTest extends TestCase
         $downloadConfig = new DownloadConfig();
         $downloadConfig->software = 'trap';
         $downloadConfig->version = '^1.13';
-        $downloadConfig->type = 'phar';
+        $downloadConfig->type = Type::Phar;
         $downloadConfig->extractPath = $this->destinationDir;
 
         // Act
@@ -103,6 +104,7 @@ final class DLoadTest extends TestCase
                         <repository type="github" uri="buggregator/trap"
                             asset-pattern="/^trap\..+$/"
                         />
+                        <binary name="trap" version-command="--version" />
                     </software>
                 </registry>
             </dload>

--- a/tests/Acceptance/DLoadTest.php
+++ b/tests/Acceptance/DLoadTest.php
@@ -37,7 +37,7 @@ final class DLoadTest extends TestCase
         $downloadConfig = new DownloadConfig();
         $downloadConfig->software = 'trap';
         $downloadConfig->version = '^1.13';
-        $downloadConfig->format = 'phar';
+        $downloadConfig->type = 'phar';
         $downloadConfig->extractPath = $this->destinationDir;
 
         // Act


### PR DESCRIPTION
# Implement `type` attribute behavior for download actions

## What was changed

- Added `type` attribute functionality for download actions with three behaviors:
  - `type="binary"` - Binary-specific processing with version validation
  - `type="phar"` - Downloads `.phar` files as executables without unpacking
  - `type="archive"` - Forces extraction even for .phar files
- Implemented combined handlers approach when `type` is not specified:
  - Processes `<binary>` sections for binary presence and version checking
  - Processes `<file>` sections during unpacking if asset is downloaded
  - Performs simple download without unpacking if no sections exist
- Updated `resources/type-attribute-implementation-spec.md` with complete feature specification
- Updated `README.md` with type attribute documentation and examples

## Why?

Different file types require different handling behaviors. Previously, there was no way to explicitly control whether a `.phar` file should be treated as an executable or unpacked as an archive. The combined handlers approach provides intuitive default behavior that processes all available software configuration sections simultaneously, while explicit type specification allows override when needed.

## Checklist

- Closes #51 
- Tested
  - [x] Acceptance tests added
- [x] Documentation

## Documentation

### Summary

Implements the `type` attribute functionality for download actions, providing different download behaviors based on file types (Binary, Archive, PHAR) while maintaining backward compatibility.

### Changes

### Default Behavior
When `type` is not specified, uses combined handlers:
- Process `<binary>` sections for binary presence and version checking
- Process `<file>` sections during unpacking if asset is downloaded  
- Perform simple download without unpacking if no sections exist

#### Explicit Type Control
Three explicit types:
- `type="binary"` - Binary-specific processing with version validation
- `type="phar"` - Downloads `.phar` files as executables without unpacking
- `type="archive"` - Forces extraction even for .phar files

#### PHAR Handling
```xml
<!-- Downloads psalm.phar as executable (no unpacking) -->
<download software="psalm" type="phar" />

<!-- Forces unpacking of psalm.phar contents -->
<download software="psalm" type="archive" />
```

### Examples

#### Combined Handlers (Default)
```xml
<software name="dev-tools">
    <binary name="cli" pattern="/^cli-.*/" />
    <file pattern="/^config\..*/" extract-path="config" />
</software>

<!-- Uses both binary and files processing -->
<download software="dev-tools" />
```

#### Explicit Type Override
```xml
<!-- Override default behavior -->
<download software="dev-tools" type="binary" />  <!-- Only binary processing -->
<download software="dev-tools" type="archive" /> <!-- Only files processing -->
```
