### PR TITLE
Stop using deprecated Command::getDefaultName()

### DIFF
--- a/bin/dload
+++ b/bin/dload
@@ -46,14 +46,14 @@ use Symfony\Component\Console\CommandLoader\FactoryCommandLoader;
     $application = new Application();
     $application->setCommandLoader(
         new FactoryCommandLoader([
-            Command\Get::getDefaultName() => static fn() => new Command\Get(),
-            Command\ListSoftware::getDefaultName() => static fn() => new Command\ListSoftware(),
-            Command\Show::getDefaultName() => static fn() => new Command\Show(),
-            Command\Init::getDefaultName() => static fn() => new Command\Init(),
-            Command\Build::getDefaultName() => static fn() => new Command\Build(),
+            Command\Get::getCommandName() => static fn() => new Command\Get(),
+            Command\ListSoftware::getCommandName() => static fn() => new Command\ListSoftware(),
+            Command\Show::getCommandName() => static fn() => new Command\Show(),
+            Command\Init::getCommandName() => static fn() => new Command\Init(),
+            Command\Build::getCommandName() => static fn() => new Command\Build(),
         ]),
     );
-    $application->setDefaultCommand(Command\Get::getDefaultName(), false);
+    $application->setDefaultCommand(Command\Get::getCommandName(), false);
     $application->setVersion(Info::version());
     $application->setName(Info::NAME);
     $application->run();

--- a/src/Command/Base.php
+++ b/src/Command/Base.php
@@ -44,20 +44,9 @@ abstract class Base extends Command
     /** @var Container IoC container with services */
     protected Container $container;
 
-    /**
-     * Configures command options.
-     *
-     * Adds option for specifying configuration file location.
-     */
-    public function configure(): void
-    {
-        parent::configure();
-        $this->addOption('config', null, InputOption::VALUE_OPTIONAL, 'Path to the configuration file');
-    }
-
     public static function getCommandName(): ?string
     {
-        if (!class_exists(AsCommand::class)) {
+        if (!\class_exists(AsCommand::class)) {
             // Fall back on lower Symfony versions
             return self::getDefaultName();
         }
@@ -69,6 +58,17 @@ abstract class Base extends Command
         }
 
         return null;
+    }
+
+    /**
+     * Configures command options.
+     *
+     * Adds option for specifying configuration file location.
+     */
+    public function configure(): void
+    {
+        parent::configure();
+        $this->addOption('config', null, InputOption::VALUE_OPTIONAL, 'Path to the configuration file');
     }
 
     /**

--- a/src/Command/Base.php
+++ b/src/Command/Base.php
@@ -7,6 +7,7 @@ namespace Internal\DLoad\Command;
 use Internal\DLoad\Bootstrap;
 use Internal\DLoad\Service\Container;
 use Internal\DLoad\Service\Logger;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -52,6 +53,22 @@ abstract class Base extends Command
     {
         parent::configure();
         $this->addOption('config', null, InputOption::VALUE_OPTIONAL, 'Path to the configuration file');
+    }
+
+    public static function getCommandName(): ?string
+    {
+        if (!class_exists(AsCommand::class)) {
+            // Fall back on lower Symfony versions
+            return self::getDefaultName();
+        }
+
+        if ($attributes = (new \ReflectionClass(static::class))->getAttributes(AsCommand::class)) {
+            /** @var AsCommand $attribute */
+            $attribute = $attributes[0]->newInstance();
+            return $attribute->name;
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
## What was changed

Symfony 8.0 removed method Command::getDefaultName(). This PR adds back support to get the name of the method. 

## Why?

Because Psalm does not support sf80, we never run symfony/command 8.0 on CI. 

## Checklist

- Closes #<!-- add issue number here -->
- Tested
  - [x] Tested manually
  - [ ] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
