### PR TITLE
add support for Gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,41 @@ GITLAB_TOKEN=your_token_here ./vendor/bin/dload get
 
 Add to CI/CD environment variables for automated downloads.
 
+## Gitlab CI configuration
+
+When you make a release in Gitlab, make sure to upload your assets to the release page via
+package manager. This can easily be done via Gitlab CLI and the `glab release upload --use-package-registry`
+command.
+
+```
+# .gitlab-ci.yml
+
+Build artifacts:
+  stage: push
+  script:
+    - mkdir bin
+    - echo "Mock binary for darwin arm" > bin/cool-darwin-arm64
+    - echo "Mock binary for darwin amd" > bin/cool-darwin-amd64
+    - echo "Mock binary for linux arm" > bin/cool-linux-arm64
+    - echo "Mock binary for linux amd" > bin/cool-linux-amd64
+  artifacts:
+    expire_in: 2 hours
+    paths:
+      - $CI_PROJECT_DIR/bin/cool-*
+  rules:
+    - if: $CI_COMMIT_TAG
+
+Release artifacts:
+    stage: deploy
+    image: gitlab/glab:latest
+    needs: [ "Build artifacts" ]
+    script:
+        - glab auth login --token $GL_TOKEN --hostname $CI_SERVER_HOST
+        - glab release upload --use-package-registry "$CI_COMMIT_TAG" ./bin/*
+    rules:
+        - if: $CI_COMMIT_TAG
+```
+
 ## Contributing
 
 Contributions welcome! Submit Pull Requests to:

--- a/README.md
+++ b/README.md
@@ -463,6 +463,14 @@ This ensures consistent Velox versions across different environments and team me
             <repository type="github" uri="vimeo/psalm" />
             <binary name="psalm.phar" pattern="/^psalm\.phar$/" />
         </software>
+        
+        <!-- GitLab repository -->
+        <software name="My cool project" alias="cool-project"
+              homepage="https://gitlab.com/path/to/my/repository"
+              description="">
+            <repository type="gitlab" uri="path/to/my/repository" asset-pattern="/^cool-.*/" />
+            <binary name="cool" pattern="/^cool-.*/" />
+        </software>
     </registry>
 </dload>
 ```
@@ -553,12 +561,13 @@ Each developer gets the correct binaries for their system:
 </actions>
 ```
 
-## GitHub API Rate Limits
+## API Rate Limits
 
 Use a personal access token to avoid rate limits:
 
 ```bash
 GITHUB_TOKEN=your_token_here ./vendor/bin/dload get
+GITLAB_TOKEN=your_token_here ./vendor/bin/dload get
 ```
 
 Add to CI/CD environment variables for automated downloads.

--- a/README.md
+++ b/README.md
@@ -601,7 +601,7 @@ Release artifacts:
     image: gitlab/glab:latest
     needs: [ "Build artifacts" ]
     script:
-        - glab auth login --token $GL_TOKEN --hostname $CI_SERVER_HOST
+        - glab auth login --job-token $CI_JOB_TOKEN --hostname $CI_SERVER_HOST
         - glab release upload --use-package-registry "$CI_COMMIT_TAG" ./bin/*
     rules:
         - if: $CI_COMMIT_TAG

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -14,6 +14,7 @@ use Internal\DLoad\Module\Common\Stability;
 use Internal\DLoad\Module\HttpClient\Factory;
 use Internal\DLoad\Module\HttpClient\Internal\NyholmFactoryImpl;
 use Internal\DLoad\Module\Repository\Internal\GitHub\Factory as GithubRepositoryFactory;
+use Internal\DLoad\Module\Repository\Internal\GitLab\Factory as GitLabRepositoryFactory;
 use Internal\DLoad\Module\Repository\RepositoryProvider;
 use Internal\DLoad\Module\Velox\ApiClient;
 use Internal\DLoad\Module\Velox\Builder;
@@ -106,7 +107,8 @@ final class Bootstrap
         $this->container->bind(
             RepositoryProvider::class,
             static fn(Container $container): RepositoryProvider => (new RepositoryProvider())
-                ->addRepositoryFactory($container->get(GithubRepositoryFactory::class)),
+                ->addRepositoryFactory($container->get(GithubRepositoryFactory::class))
+                ->addRepositoryFactory($container->get(GitLabRepositoryFactory::class)),
         );
         $this->container->bind(BinaryProvider::class, BinaryProviderImpl::class);
         $this->container->bind(Factory::class, NyholmFactoryImpl::class);

--- a/src/Module/Config/Schema/GitLab.php
+++ b/src/Module/Config/Schema/GitLab.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\DLoad\Module\Config\Schema;
+
+use Internal\DLoad\Module\Common\Internal\Attribute\Env;
+
+/**
+ * GitLab API configuration.
+ *
+ * Contains authentication settings for GitLab API access.
+ *
+ * @internal
+ */
+final class GitLab
+{
+    /** @var string|null $token API token for GitLab authentication */
+    #[Env('GITLAB_TOKEN')]
+    public ?string $token = null;
+}

--- a/src/Module/Repository/Internal/GitLab/Api/Client.php
+++ b/src/Module/Repository/Internal/GitLab/Api/Client.php
@@ -80,8 +80,8 @@ final class Client
     {
         $response = $this->client->sendRequest($request);
 
-        if ($response->getStatusCode() === 403) {
-            throw GitLabRateLimitException::fromApiResponse();
+        if ($response->getStatusCode() === 429) {
+            throw new GitLabRateLimitException();
         }
 
         return $response;

--- a/src/Module/Repository/Internal/GitLab/Api/Client.php
+++ b/src/Module/Repository/Internal/GitLab/Api/Client.php
@@ -42,6 +42,24 @@ final class Client
     }
 
     /**
+     * @throws GitLabRateLimitException
+     * @throws ClientExceptionInterface
+     */
+    public function downloadArtifact(string|UriInterface $uri): ResponseInterface
+    {
+        $headers = [];
+        if ($this->gitLabConfig->token !== null) {
+            $headers = [
+                'PRIVATE-TOKEN' =>  $this->gitLabConfig->token
+            ];
+        }
+
+        $request = $this->httpFactory->request(Method::Get, $uri, $headers);
+
+        return $this->sendRequest($request);
+    }
+
+    /**
      * @param Method|non-empty-string $method
      * @param array<string, string> $headers
      * @throws GitLabRateLimitException

--- a/src/Module/Repository/Internal/GitLab/Api/Client.php
+++ b/src/Module/Repository/Internal/GitLab/Api/Client.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\DLoad\Module\Repository\Internal\GitLab\Api;
+
+use Internal\DLoad\Module\Config\Schema\GitLab;
+use Internal\DLoad\Module\HttpClient\Factory as HttpFactory;
+use Internal\DLoad\Module\HttpClient\Method;
+use Internal\DLoad\Module\Repository\Internal\GitLab\Exception\GitLabRateLimitException;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * HTTP client wrapper with GitLab-specific error handling and authentication.
+ *
+ * Detects and handles GitLab Rate Limit responses automatically.
+ * Adds GitLab API token authentication when available.
+ *
+ * @internal
+ * @psalm-internal Internal\DLoad\Module\Repository\Internal\GitLab
+ */
+final class Client
+{
+    /**
+     * @var array<non-empty-string, non-empty-string>
+     */
+    private array $defaultHeaders = [
+        'accept' => 'application/json',
+    ];
+
+    public function __construct(
+        private readonly HttpFactory $httpFactory,
+        private readonly ClientInterface $client,
+        private readonly GitLab $gitLabConfig,
+    ) {
+        // Add authorization header if token is available
+        $this->gitLabConfig->token !== null and $this->defaultHeaders['authorization'] = 'Bearer ' . $this->gitLabConfig->token;
+    }
+
+    /**
+     * @param Method|non-empty-string $method
+     * @param array<string, string> $headers
+     * @throws GitLabRateLimitException
+     * @throws ClientExceptionInterface
+     */
+    public function request(Method|string $method, string|UriInterface $uri, array $headers = []): ResponseInterface
+    {
+        $request = $this->httpFactory->request($method, $uri, $headers + $this->defaultHeaders);
+
+        return $this->sendRequest($request);
+    }
+
+    /**
+     * @throws GitLabRateLimitException
+     * @throws ClientExceptionInterface
+     */
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $response = $this->client->sendRequest($request);
+
+        if ($response->getStatusCode() === 403) {
+            throw GitLabRateLimitException::fromApiResponse();
+        }
+
+        return $response;
+    }
+}

--- a/src/Module/Repository/Internal/GitLab/Api/Client.php
+++ b/src/Module/Repository/Internal/GitLab/Api/Client.php
@@ -50,7 +50,7 @@ final class Client
         $headers = [];
         if ($this->gitLabConfig->token !== null) {
             $headers = [
-                'PRIVATE-TOKEN' =>  $this->gitLabConfig->token
+                'PRIVATE-TOKEN' =>  $this->gitLabConfig->token,
             ];
         }
 

--- a/src/Module/Repository/Internal/GitLab/Api/RepositoryApi.php
+++ b/src/Module/Repository/Internal/GitLab/Api/RepositoryApi.php
@@ -33,9 +33,6 @@ final class RepositoryApi
      */
     public readonly string $repositoryPath;
 
-    /**
-     * @param non-empty-string $repo
-     */
     public function __construct(
         private readonly Client $client,
         private readonly HttpFactory $httpFactory,
@@ -53,9 +50,10 @@ final class RepositoryApi
      */
     public function downloadArtifact(string $repositoryPath, string $releaseName, string $fileName): ResponseInterface
     {
-        $url = sprintf(self::URL_RELEASE_ASSET, urlencode($repositoryPath), $releaseName, $fileName);
+        $url = \sprintf(self::URL_RELEASE_ASSET, \urlencode($repositoryPath), $releaseName, $fileName);
         return $this->client->downloadArtifact($url);
     }
+
     /**
      * @param Method|non-empty-string $method
      * @param array<string, string> $headers
@@ -73,7 +71,7 @@ final class RepositoryApi
      */
     public function getRepository(): RepositoryInfo
     {
-        $response = $this->request(Method::Get, \sprintf(self::URL_REPOSITORY, urlencode($this->repositoryPath)));
+        $response = $this->request(Method::Get, \sprintf(self::URL_REPOSITORY, \urlencode($this->repositoryPath)));
 
         /** @var array{
          *     name: string,
@@ -158,7 +156,7 @@ final class RepositoryApi
         return $this->request(
             Method::Get,
             $this->httpFactory->uri(
-                \sprintf(self::URL_RELEASES, urlencode($this->repositoryPath)),
+                \sprintf(self::URL_RELEASES, \urlencode($this->repositoryPath)),
                 ['page' => $page],
             ),
         );

--- a/src/Module/Repository/Internal/GitLab/Api/RepositoryApi.php
+++ b/src/Module/Repository/Internal/GitLab/Api/RepositoryApi.php
@@ -26,6 +26,7 @@ final class RepositoryApi
 {
     private const URL_REPOSITORY = 'https://gitlab.com/api/v4/projects/%s';
     private const URL_RELEASES = 'https://gitlab.com/api/v4/projects/%s/releases';
+    private const URL_RELEASE_ASSET = 'https://gitlab.com/api/v4/projects/%s/releases/%s/downloads/%s';
 
     /**
      * @var non-empty-string
@@ -43,6 +44,18 @@ final class RepositoryApi
         $this->repositoryPath = $projectPath;
     }
 
+    /**
+     * @param non-empty-string $repositoryPath
+     * @param non-empty-string $releaseName
+     * @param non-empty-string $fileName
+     * @throws GitLabRateLimitException
+     * @throws ClientExceptionInterface
+     */
+    public function downloadArtifact(string $repositoryPath, string $releaseName, string $fileName): ResponseInterface
+    {
+        $url = sprintf(self::URL_RELEASE_ASSET, urlencode($repositoryPath), $releaseName, $fileName);
+        return $this->client->downloadArtifact($url);
+    }
     /**
      * @param Method|non-empty-string $method
      * @param array<string, string> $headers

--- a/src/Module/Repository/Internal/GitLab/Api/RepositoryApi.php
+++ b/src/Module/Repository/Internal/GitLab/Api/RepositoryApi.php
@@ -103,15 +103,18 @@ final class RepositoryApi
                     $response = $this->releasesRequest($currentPage);
 
                     /** @var array<array-key, array{
-                     *     name: string|null,
-                     *     tag_name: string,
-                     *     released_at: string,
+                     *     name: non-empty-string|null,
+                     *     tag_name: non-empty-string,
+                     *     description: null|non-empty-string,
+                     *     created_at: non-empty-string,
+                     *     released_at: non-empty-string,
                      *     assets: array{
                      *         links: list<array{
-                     *          name: string,
-                     *          url: string,
-                     *          direct_asset_url: string,
-                     *      }>
+                     *             name: non-empty-string,
+                     *             url: non-empty-string,
+                     *             direct_asset_url?: non-empty-string,
+                     *             link_type: non-empty-string,
+                     *         }>
                      *     },
                      *     upcoming_release: bool
                      * }> $data */

--- a/src/Module/Repository/Internal/GitLab/Api/RepositoryApi.php
+++ b/src/Module/Repository/Internal/GitLab/Api/RepositoryApi.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\DLoad\Module\Repository\Internal\GitLab\Api;
+
+use Internal\DLoad\Module\HttpClient\Factory as HttpFactory;
+use Internal\DLoad\Module\HttpClient\Method;
+use Internal\DLoad\Module\Repository\Internal\GitLab\Api\Response\ReleaseInfo;
+use Internal\DLoad\Module\Repository\Internal\GitLab\Api\Response\RepositoryInfo;
+use Internal\DLoad\Module\Repository\Internal\GitLab\Exception\GitLabRateLimitException;
+use Internal\DLoad\Module\Repository\Internal\Paginator;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * API client for specific GitLab repository operations.
+ *
+ * Bound to specific owner/repo pair and provides typed methods for GitLab API operations.
+ *
+ * @internal
+ * @psalm-internal Internal\DLoad\Module\Repository\Internal\GitLab
+ */
+final class RepositoryApi
+{
+    private const URL_REPOSITORY = 'https://gitlab.com/api/v4/projects/%s';
+    private const URL_RELEASES = 'https://gitlab.com/api/v4/projects/%s/releases';
+
+    /**
+     * @var non-empty-string
+     */
+    public readonly string $repositoryPath;
+
+    /**
+     * @param non-empty-string $repo
+     */
+    public function __construct(
+        private readonly Client $client,
+        private readonly HttpFactory $httpFactory,
+        string $projectPath,
+    ) {
+        $this->repositoryPath = $projectPath;
+    }
+
+    /**
+     * @param Method|non-empty-string $method
+     * @param array<string, string> $headers
+     * @throws GitLabRateLimitException
+     * @throws ClientExceptionInterface
+     */
+    public function request(Method|string $method, string|UriInterface $uri, array $headers = []): ResponseInterface
+    {
+        return $this->client->request($method, $uri, $headers);
+    }
+
+    /**
+     * @throws GitLabRateLimitException
+     * @throws ClientExceptionInterface
+     */
+    public function getRepository(): RepositoryInfo
+    {
+        $response = $this->request(Method::Get, \sprintf(self::URL_REPOSITORY, urlencode($this->repositoryPath)));
+
+        /** @var array{
+         *     name: string,
+         *     name_with_namespace: string,
+         *     description: string|null,
+         *     web_url: string,
+         *     visibility: bool,
+         *     created_at: string,
+         *     updated_at: string
+         * } $data */
+        $data = \json_decode($response->getBody()->__toString(), true, 512, JSON_THROW_ON_ERROR);
+
+        return RepositoryInfo::fromApiResponse($data);
+    }
+
+    /**
+     * @param int<1, max> $page
+     * @return Paginator<ReleaseInfo>
+     * @throws GitLabRateLimitException
+     * @throws ClientExceptionInterface
+     */
+    public function getReleases(int $page = 1): Paginator
+    {
+        $pageLoader = function () use ($page): \Generator {
+            $currentPage = $page;
+
+            do {
+                try {
+                    $response = $this->releasesRequest($currentPage);
+
+                    /** @var array<array-key, array{
+                     *     name: string|null,
+                     *     tag_name: string,
+                     *     released_at: string,
+                     *     assets: array{
+                     *         links: list<array{
+                     *          name: string,
+                     *          url: string,
+                     *          direct_asset_url: string,
+                     *      }>
+                     *     },
+                     *     upcoming_release: bool
+                     * }> $data */
+                    $data = \json_decode($response->getBody()->__toString(), true, 512, JSON_THROW_ON_ERROR);
+
+                    // If empty response, no more pages
+                    if ($data === []) {
+                        return;
+                    }
+
+                    $releases = [];
+                    foreach ($data as $releaseData) {
+                        try {
+                            $releases[] = ReleaseInfo::fromApiResponse($releaseData);
+                        } catch (\Throwable) {
+                            // Skip invalid releases
+                            continue;
+                        }
+                    }
+
+                    yield $releases;
+
+                    // Check if there are more pages
+                    $hasMorePages = $this->hasNextPage($response);
+                    $currentPage++;
+                } catch (ClientExceptionInterface) {
+                    return;
+                }
+            } while ($hasMorePages);
+        };
+
+        return Paginator::createFromGenerator($pageLoader(), null);
+    }
+
+    /**
+     * @param positive-int $page
+     * @throws GitLabRateLimitException
+     * @throws ClientExceptionInterface
+     */
+    private function releasesRequest(int $page): ResponseInterface
+    {
+        return $this->request(
+            Method::Get,
+            $this->httpFactory->uri(
+                \sprintf(self::URL_RELEASES, urlencode($this->repositoryPath)),
+                ['page' => $page],
+            ),
+        );
+    }
+
+    private function hasNextPage(ResponseInterface $response): bool
+    {
+        $headers = $response->getHeaders();
+        $link = $headers['link'] ?? [];
+
+        if (!isset($link[0])) {
+            return false;
+        }
+
+        return \str_contains($link[0], 'rel="next"');
+    }
+}

--- a/src/Module/Repository/Internal/GitLab/Api/Response/AssetInfo.php
+++ b/src/Module/Repository/Internal/GitLab/Api/Response/AssetInfo.php
@@ -15,24 +15,28 @@ final class AssetInfo
     /**
      * @param non-empty-string $name
      * @param non-empty-string $downloadUrl
+     * @param non-empty-string|null $linkType
      */
     public function __construct(
         public readonly string $name,
         public readonly string $downloadUrl,
+        public readonly ?string $linkType = null,
     ) {}
 
     /**
      * @param array{
-     *     name: string,
-     *     url: string,
-     *     direct_asset_url: string,
+     *     name: non-empty-string,
+     *     url: non-empty-string,
+     *     direct_asset_url?: non-empty-string,
+     *     link_type: non-empty-string,
      * } $data
      */
     public static function fromApiResponse(array $data): self
     {
         return new self(
             name: $data['name'],
-            downloadUrl: $data['url'],
+            downloadUrl: !empty($data['direct_asset_url']) ? $data['direct_asset_url'] : $data['url'],
+            linkType: $data['link_type'] ?? null,
         );
     }
 }

--- a/src/Module/Repository/Internal/GitLab/Api/Response/AssetInfo.php
+++ b/src/Module/Repository/Internal/GitLab/Api/Response/AssetInfo.php
@@ -32,7 +32,7 @@ final class AssetInfo
     {
         return new self(
             name: $data['name'],
-            downloadUrl: $data['direct_asset_url'],
+            downloadUrl: $data['url'],
         );
     }
 }

--- a/src/Module/Repository/Internal/GitLab/Api/Response/AssetInfo.php
+++ b/src/Module/Repository/Internal/GitLab/Api/Response/AssetInfo.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\DLoad\Module\Repository\Internal\GitLab\Api\Response;
+
+/**
+ * GitLab Asset Data Transfer Object.
+ *
+ * @internal
+ * @psalm-internal Internal\DLoad\Module\Repository\Internal\GitLab
+ */
+final class AssetInfo
+{
+    /**
+     * @param non-empty-string $name
+     * @param non-empty-string $downloadUrl
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly string $downloadUrl,
+    ) {}
+
+    /**
+     * @param array{
+     *     name: string,
+     *     url: string,
+     *     direct_asset_url: string,
+     * } $data
+     */
+    public static function fromApiResponse(array $data): self
+    {
+        return new self(
+            name: $data['name'],
+            downloadUrl: $data['direct_asset_url'],
+        );
+    }
+}

--- a/src/Module/Repository/Internal/GitLab/Api/Response/ReleaseInfo.php
+++ b/src/Module/Repository/Internal/GitLab/Api/Response/ReleaseInfo.php
@@ -27,15 +27,18 @@ final class ReleaseInfo
 
     /**
      * @param array{
-     *      name: string|null,
-     *      tag_name: string,
-     *      released_at: string,
-     *     assets: array{
-     *         links: list<array{
-     *          name: string,
-     *          url: string,
-     *          direct_asset_url: string,
-     *        }>
+     *      name: non-empty-string|null,
+     *      tag_name: non-empty-string,
+     *      description: null|non-empty-string,
+     *      created_at: non-empty-string,
+     *      released_at: non-empty-string,
+     *      assets: array{
+     *          links: list<array{
+     *              name: non-empty-string,
+     *              url: non-empty-string,
+     *              direct_asset_url?: non-empty-string,
+     *              link_type: non-empty-string,
+     *          }>
      *      },
      *      upcoming_release: bool
      * } $data

--- a/src/Module/Repository/Internal/GitLab/Api/Response/ReleaseInfo.php
+++ b/src/Module/Repository/Internal/GitLab/Api/Response/ReleaseInfo.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\DLoad\Module\Repository\Internal\GitLab\Api\Response;
+
+/**
+ * GitLab Release Data Transfer Object.
+ *
+ * @internal
+ * @psalm-internal Internal\DLoad\Module\Repository\Internal\GitLab
+ */
+final class ReleaseInfo
+{
+    /**
+     * @param non-empty-string $name
+     * @param non-empty-string $tagName
+     * @param list<AssetInfo> $assets
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly string $tagName,
+        public readonly \DateTimeImmutable $publishedAt,
+        public readonly array $assets,
+        public readonly bool $prerelease,
+    ) {}
+
+    /**
+     * @param array{
+     *      name: string|null,
+     *      tag_name: string,
+     *      released_at: string,
+     *     assets: array{
+     *         links: list<array{
+     *          name: string,
+     *          url: string,
+     *          direct_asset_url: string,
+     *        }>
+     *      },
+     *      upcoming_release: bool
+     * } $data
+     */
+    public static function fromApiResponse(array $data): self
+    {
+        $assets = [];
+        foreach ($data['assets']['links'] as $assetData) {
+            $assets[] = AssetInfo::fromApiResponse($assetData);
+        }
+
+        return new self(
+            name: $data['name'] ?? $data['tag_name'],
+            tagName: $data['tag_name'],
+            publishedAt: new \DateTimeImmutable($data['released_at']),
+            assets: $assets,
+            prerelease: $data['upcoming_release'],
+        );
+    }
+}

--- a/src/Module/Repository/Internal/GitLab/Api/Response/RepositoryInfo.php
+++ b/src/Module/Repository/Internal/GitLab/Api/Response/RepositoryInfo.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\DLoad\Module\Repository\Internal\GitLab\Api\Response;
+
+/**
+ * GitLab Repository Data Transfer Object.
+ *
+ * @internal
+ * @psalm-internal Internal\DLoad\Module\Repository\Internal\GitLab
+ */
+final class RepositoryInfo
+{
+    /**
+     * @param non-empty-string $name
+     * @param non-empty-string $fullName
+     * @param non-empty-string $htmlUrl
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly string $fullName,
+        public readonly string $description,
+        public readonly string $htmlUrl,
+        public readonly bool $private,
+        public readonly \DateTimeImmutable $createdAt,
+        public readonly \DateTimeImmutable $updatedAt,
+    ) {}
+
+    /**
+     * @param array{
+     *     name: string,
+     *     name_with_namespace: string,
+     *     description: string|null,
+     *     web_url: string,
+     *     visibility: bool,
+     *     created_at: string,
+     *     updated_at: string
+     * } $data
+     */
+    public static function fromApiResponse(array $data): self
+    {
+        return new self(
+            name: $data['name'],
+            fullName: $data['name_with_namespace'],
+            description: $data['description'] ?? '',
+            htmlUrl: $data['web_url'],
+            private: $data['visibility'] === 'private',
+            createdAt: new \DateTimeImmutable($data['created_at']),
+            updatedAt: new \DateTimeImmutable($data['updated_at']),
+        );
+    }
+}

--- a/src/Module/Repository/Internal/GitLab/Exception/GitLabRateLimitException.php
+++ b/src/Module/Repository/Internal/GitLab/Exception/GitLabRateLimitException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\DLoad\Module\Repository\Internal\GitLab\Exception;
+
+/**
+ * Exception thrown when GitLab API rate limit is exceeded.
+ *
+ * @internal
+ * @psalm-internal Internal\DLoad\Module\Repository\Internal\GitLab
+ */
+final class GitLabRateLimitException extends \RuntimeException
+{
+    public function __construct(
+        string $message = 'GitLab API rate limit exceeded. Check the GitLab Token or try again later.',
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+
+    /**
+     * Creates exception from GitLab API response body.
+     */
+    public static function fromApiResponse(): self
+    {
+        return new self();
+    }
+}

--- a/src/Module/Repository/Internal/GitLab/Exception/GitLabRateLimitException.php
+++ b/src/Module/Repository/Internal/GitLab/Exception/GitLabRateLimitException.php
@@ -18,12 +18,4 @@ final class GitLabRateLimitException extends \RuntimeException
     ) {
         parent::__construct($message, 0, $previous);
     }
-
-    /**
-     * Creates exception from GitLab API response body.
-     */
-    public static function fromApiResponse(): self
-    {
-        return new self();
-    }
 }

--- a/src/Module/Repository/Internal/GitLab/Factory.php
+++ b/src/Module/Repository/Internal/GitLab/Factory.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\DLoad\Module\Repository\Internal\GitLab;
+
+use Internal\DLoad\Module\Config\Schema\Embed\Repository as RepositoryConfig;
+use Internal\DLoad\Module\Config\Schema\GitLab;
+use Internal\DLoad\Module\HttpClient\Factory as HttpFactory;
+use Internal\DLoad\Module\Repository\Internal\GitLab\Api\Client;
+use Internal\DLoad\Module\Repository\Internal\GitLab\Api\RepositoryApi;
+use Internal\DLoad\Module\Repository\RepositoryFactory;
+
+/**
+ * Factory for creating GitLab repository instances.
+ *
+ * This factory creates instances of {@see GitLabRepository} based on the provided configuration.
+ * It checks if the configuration type is 'gitlab' and then initializes the GitLab API client
+ * and repository API for the specified organization and repository.
+ *
+ * @internal
+ * @psalm-internal Internal\DLoad\Module\Repository
+ */
+final class Factory implements RepositoryFactory
+{
+    private readonly Client $gitLabClient;
+
+    public function __construct(
+        private readonly HttpFactory $httpFactory,
+        GitLab $gitLabConfig,
+    ) {
+        $this->gitLabClient = new Client(
+            $httpFactory,
+            $httpFactory->client(),
+            $gitLabConfig,
+        );
+    }
+
+    public function supports(RepositoryConfig $config): bool
+    {
+        return \strtolower($config->type) === 'gitlab';
+    }
+
+    public function create(RepositoryConfig $config): GitLabRepository
+    {
+        $uri = \parse_url($config->uri, PHP_URL_PATH) ?? $config->uri;
+        $api = $this->createRepositoryApi($uri);
+
+        return new GitLabRepository($api, $uri);
+    }
+
+    /**
+     * @param non-empty-string $projectPath
+     */
+    private function createRepositoryApi(string $projectPath): RepositoryApi
+    {
+        return new RepositoryApi($this->gitLabClient, $this->httpFactory, $projectPath);
+    }
+}

--- a/src/Module/Repository/Internal/GitLab/GitLabAsset.php
+++ b/src/Module/Repository/Internal/GitLab/GitLabAsset.php
@@ -7,7 +7,6 @@ namespace Internal\DLoad\Module\Repository\Internal\GitLab;
 use Internal\Destroy\Destroyable;
 use Internal\DLoad\Module\Common\Architecture;
 use Internal\DLoad\Module\Common\OperatingSystem;
-use Internal\DLoad\Module\HttpClient\Method;
 use Internal\DLoad\Module\Repository\Internal\Asset;
 use Internal\DLoad\Module\Repository\Internal\GitLab\Api\Response\AssetInfo;
 use Internal\DLoad\Module\Repository\Internal\GitLab\Api\RepositoryApi;

--- a/src/Module/Repository/Internal/GitLab/GitLabAsset.php
+++ b/src/Module/Repository/Internal/GitLab/GitLabAsset.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\DLoad\Module\Repository\Internal\GitLab;
+
+use Internal\Destroy\Destroyable;
+use Internal\DLoad\Module\Common\Architecture;
+use Internal\DLoad\Module\Common\OperatingSystem;
+use Internal\DLoad\Module\HttpClient\Method;
+use Internal\DLoad\Module\Repository\Internal\Asset;
+use Internal\DLoad\Module\Repository\Internal\GitLab\Api\Response\AssetInfo;
+use Internal\DLoad\Module\Repository\Internal\GitLab\Api\RepositoryApi;
+use Psr\Http\Client\ClientExceptionInterface;
+
+/**
+ * GitLab Asset class representing a downloadable asset from a GitLab release.
+ *
+ * @internal
+ * @psalm-internal Internal\DLoad\Module\Repository\Internal\GitLab
+ */
+final class GitLabAsset extends Asset implements Destroyable
+{
+    /**
+     * @param non-empty-string $name
+     * @param non-empty-string $uri
+     */
+    private function __construct(
+        private readonly RepositoryApi $api,
+        GitLabRelease $release,
+        string $name,
+        string $uri,
+    ) {
+        parent::__construct(
+            release: $release,
+            name: $name,
+            uri: $uri,
+            os: OperatingSystem::tryFromBuildName($name),
+            arch: Architecture::tryFromBuildName($name),
+        );
+    }
+
+    public static function fromDTO(
+        RepositoryApi $api,
+        GitLabRelease $release,
+        AssetInfo $dto,
+    ): self {
+        return new self($api, $release, $dto->name, $dto->downloadUrl);
+    }
+
+    /**
+     * @param null|\Closure(int $dlNow, int|null $dlSize, array $info): mixed $progress
+     *        throwing any exceptions MUST abort the request;
+     *        it MUST be called on DNS resolution, on arrival of headers and on completion;
+     *        it SHOULD be called on upload/download of data and at least 1/s
+     *
+     * @return \Generator<int, string, mixed, void>
+     * @throws ClientExceptionInterface
+     */
+    public function download(?\Closure $progress = null): \Generator
+    {
+        $response = $this->api->request(Method::Get, $this->getUri());
+
+        $body = $response->getBody();
+        $size = $body->getSize();
+        $loaded = 0;
+
+        while (!$body->eof()) {
+            $chunk = $body->read(8192);
+            $loaded += \strlen($chunk);
+            $progress === null or $progress($loaded, $size, []);
+            yield $chunk;
+        }
+    }
+
+    public function destroy(): void
+    {
+        unset($this->release);
+    }
+}

--- a/src/Module/Repository/Internal/GitLab/GitLabAsset.php
+++ b/src/Module/Repository/Internal/GitLab/GitLabAsset.php
@@ -59,7 +59,7 @@ final class GitLabAsset extends Asset implements Destroyable
      */
     public function download(?\Closure $progress = null): \Generator
     {
-        $response = $this->api->request(Method::Get, $this->getUri());
+        $response = $this->api->downloadArtifact($this->release->getRepository()->getName(), $this->release->getName(), $this->getName());
 
         $body = $response->getBody();
         $size = $body->getSize();

--- a/src/Module/Repository/Internal/GitLab/GitLabRelease.php
+++ b/src/Module/Repository/Internal/GitLab/GitLabRelease.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\DLoad\Module\Repository\Internal\GitLab;
+
+use Internal\Destroy\Destroyable;
+use Internal\DLoad\Module\Repository\Collection\AssetsCollection;
+use Internal\DLoad\Module\Repository\Internal\GitLab\Api\Response\ReleaseInfo;
+use Internal\DLoad\Module\Repository\Internal\GitLab\Api\RepositoryApi;
+use Internal\DLoad\Module\Repository\Internal\Release;
+use Internal\DLoad\Module\Version\Version;
+
+/**
+ * GitLab Release class representing a release in a GitLab repository.
+ *
+ * @internal
+ * @psalm-internal Internal\DLoad\Module\Repository\Internal\GitLab
+ */
+final class GitLabRelease extends Release implements Destroyable
+{
+    /**
+     * @param non-empty-string $name
+     */
+    private function __construct(
+        GitLabRepository $repository,
+        string $name,
+        Version $version,
+    ) {
+        parent::__construct($repository, $name, $version);
+    }
+
+    public static function fromDTO(
+        RepositoryApi $api,
+        GitLabRepository $repository,
+        ReleaseInfo $dto,
+    ): self {
+        $version = Version::fromVersionString($dto->tagName);
+        $result = new self($repository, $dto->name, $version);
+
+        $result->assets = AssetsCollection::create(static function () use ($api, $result, $dto): \Generator {
+            foreach ($dto->assets as $assetDTO) {
+                yield GitLabAsset::fromDTO($api, $result, $assetDTO);
+            }
+        });
+
+        return $result;
+    }
+
+    public function destroy(): void
+    {
+        $this->assets === null or $this->assets->map(
+            static fn(object $asset) => $asset instanceof Destroyable and $asset->destroy(),
+        );
+
+        unset($this->assets, $this->repository);
+    }
+}

--- a/src/Module/Repository/Internal/GitLab/GitLabRepository.php
+++ b/src/Module/Repository/Internal/GitLab/GitLabRepository.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\DLoad\Module\Repository\Internal\GitLab;
+
+use Internal\Destroy\Destroyable;
+use Internal\DLoad\Module\Repository\Collection\ReleasesCollection;
+use Internal\DLoad\Module\Repository\Internal\GitLab\Api\RepositoryApi;
+use Internal\DLoad\Module\Repository\Internal\GitLab\Exception\GitLabRateLimitException;
+use Internal\DLoad\Module\Repository\Repository;
+
+/**
+ * GitLab Repository class representing a GitLab repository.
+ *
+ * @internal
+ * @psalm-internal Internal\DLoad\Module\Repository\Internal\GitLab
+ */
+final class GitLabRepository implements Repository, Destroyable
+{
+    private ?ReleasesCollection $releases = null;
+
+    /**
+     * Package name in format "owner/repository"
+     *
+     * @var non-empty-string
+     */
+    private readonly string $name;
+
+    /**
+     * @param non-empty-string $projectPath
+     */
+    public function __construct(
+        private readonly RepositoryApi $api,
+        string $projectPath,
+    ) {
+        $this->name = $projectPath;
+    }
+
+    /**
+     * Returns a lazily loaded collection of repository releases.
+     * Pages are loaded only when needed during iteration or filtering.
+     */
+    public function getReleases(): ReleasesCollection
+    {
+        if ($this->releases !== null) {
+            return $this->releases;
+        }
+
+        // Create a generator function for lazy loading release pages
+        $pageLoader = function (): \Generator {
+            $page = 0;
+
+            do {
+                try {
+                    // to avoid first eager loading because of generator
+                    yield [];
+
+                    $paginator = $this->api->getReleases(++$page);
+                    $releases = $paginator->getPageItems();
+
+                    $toYield = [];
+                    foreach ($releases as $releaseDTO) {
+                        try {
+                            $toYield[] = GitLabRelease::fromDTO($this->api, $this, $releaseDTO);
+                        } catch (\Throwable) {
+                            // Skip invalid releases
+                            continue;
+                        }
+                    }
+                    yield $toYield;
+
+                    // Check if there are more pages by getting next page
+                    $hasMorePages = $paginator->getNextPage() !== null;
+                } catch (GitLabRateLimitException $e) {
+                    throw $e;
+                } catch (\Throwable) {
+                    return;
+                }
+            } while ($hasMorePages);
+        };
+
+        // Create paginator
+        $paginator = \Internal\DLoad\Module\Repository\Internal\Paginator::createFromGenerator($pageLoader(), null);
+
+        // Create a collection with the paginator
+        $this->releases = ReleasesCollection::create($paginator);
+
+        return $this->releases;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function destroy(): void
+    {
+        $this->releases === null or $this->releases->map(
+            static fn(object $release) => $release instanceof Destroyable and $release->destroy(),
+        );
+
+        unset($this->releases);
+    }
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! -->

## What was changed

I copied and modified the Github support to make sure I can use the Gitlab API to download my private resources

## Why?

I love the fact that I can download binaries and someone else take care of figuring out what architecture. 

## Checklist

- Closes #<!-- add issue number here -->
- Tested
  - [x] Tested manually
  - [ ] Unit tests added
- [x] Documentation <!--- Remove if not needed -->
